### PR TITLE
Finish migration of oltpbench to BenchBase.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,19 +5,19 @@
 # - Service containers: https://docs.github.com/en/actions/guides/creating-postgresql-service-containers
 #
 # The CI jobs are set up as follows:
-# - One job to build, (TODO: run tests), and upload artifacts.
+# - One job to build and upload artifacts.
 # - One job per DBMS test suite.
 
-name: OLTPBench (Java with Maven)
+name: BenchBase (Java with Maven)
 
 on:
   push:
-    branches: [ oltpbench_tim ]
+    branches: [ main ]
   pull_request_target:
-    branches: [ oltpbench_tim ]
+    branches: [ main ]
 
 env:
-  OLTPBENCH_POM_VERSION: 20.1.3-SNAPSHOT
+  POM_VERSION: 2021
 
 jobs:
   build-and-upload:
@@ -33,18 +33,18 @@ jobs:
       run: mvn -B package --file pom.xml
     - name: Rename artifacts.
       run: |
-        mv target/oltpbench2-$OLTPBENCH_POM_VERSION.zip target/oltpbench2.zip
-        mv target/oltpbench2-$OLTPBENCH_POM_VERSION.tgz target/oltpbench2.tgz
+        mv target/benchbase-$POM_VERSION.zip target/benchbase.zip
+        mv target/benchbase-$POM_VERSION.tgz target/benchbase.tgz
     - name: Upload ZIP artifact.
       uses: actions/upload-artifact@v2
       with:
-        name: oltpbench2.zip
-        path: target/oltpbench2.zip
+        name: benchbase.zip
+        path: target/benchbase.zip
     - name: Upload TGZ artifact.
       uses: actions/upload-artifact@v2
       with:
-        name: oltpbench2.tgz
-        path: target/oltpbench2.tgz
+        name: benchbase.tgz
+        path: target/benchbase.tgz
 
   mysql:
     runs-on: ubuntu-latest
@@ -75,133 +75,133 @@ jobs:
       - name: Extract TGZ artifact in target/.
         working-directory: target
         run: |
-          tar xvzf oltpbench2-$OLTPBENCH_POM_VERSION.tgz
-          mv oltpbench2-$OLTPBENCH_POM_VERSION oltpbench2-extracted
+          tar xvzf benchbase-$POM_VERSION.tgz
+          mv benchbase-$POM_VERSION benchbase-extracted
       - name: AuctionMark
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b auctionmark -c config/mysql/sample_auctionmark_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b auctionmark -c config/mysql/sample_auctionmark_config.xml --create=true --load=true --execute=true
       - name: CH-benCHmark
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b tpcc -c config/mysql/sample_tpcc_config.xml --create=true --load=true
-          java -jar oltpbench2.jar -b chbenchmark -c config/mysql/sample_chbenchmark_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b tpcc -c config/mysql/sample_tpcc_config.xml --create=true --load=true
+          java -jar benchbase.jar -b chbenchmark -c config/mysql/sample_chbenchmark_config.xml --create=true --load=true --execute=true
       - name: Epinions.com
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b epinions -c config/mysql/sample_epinions_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b epinions -c config/mysql/sample_epinions_config.xml --create=true --load=true --execute=true
       - name: hyadapt
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b hyadapt -c config/mysql/sample_hyadapt_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b hyadapt -c config/mysql/sample_hyadapt_config.xml --create=true --load=true --execute=true
       - name: noop
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b noop -c config/mysql/sample_noop_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b noop -c config/mysql/sample_noop_config.xml --create=true --load=true --execute=true
       - name: Resource Stresser
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b resourcestresser -c config/mysql/sample_resourcestresser_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b resourcestresser -c config/mysql/sample_resourcestresser_config.xml --create=true --load=true --execute=true
       - name: SEATS
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b seats -c config/mysql/sample_seats_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b seats -c config/mysql/sample_seats_config.xml --create=true --load=true --execute=true
       - name: SIBench
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b sibench -c config/mysql/sample_sibench_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b sibench -c config/mysql/sample_sibench_config.xml --create=true --load=true --execute=true
       - name: SmallBank
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b smallbank -c config/mysql/sample_smallbank_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b smallbank -c config/mysql/sample_smallbank_config.xml --create=true --load=true --execute=true
       - name: TATP
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b tatp -c config/mysql/sample_tatp_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b tatp -c config/mysql/sample_tatp_config.xml --create=true --load=true --execute=true
       - name: TPC-C
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b tpcc -c config/mysql/sample_tpcc_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b tpcc -c config/mysql/sample_tpcc_config.xml --create=true --load=true --execute=true
       # TPC-DS does not have a sample configuration available right now.
       # - name: TPC-DS
-      #   working-directory: target/oltpbench2-extracted
+      #   working-directory: target/benchbase-extracted
       #   env:
       #     MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
       #   run: |
       #     mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-      #     java -jar oltpbench2.jar -b tpcds -c config/mysql/sample_tpcds_config.xml --create=true --load=true --execute=true
+      #     java -jar benchbase.jar -b tpcds -c config/mysql/sample_tpcds_config.xml --create=true --load=true --execute=true
       - name: TPC-H
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uroot -prootyMcRooty -e "SET GLOBAL local_infile=1"
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b tpch -c config/mysql/sample_tpch_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b tpch -c config/mysql/sample_tpch_config.xml --create=true --load=true --execute=true
       - name: Twitter
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b twitter -c config/mysql/sample_twitter_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b twitter -c config/mysql/sample_twitter_config.xml --create=true --load=true --execute=true
       - name: Voter
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b voter -c config/mysql/sample_voter_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b voter -c config/mysql/sample_voter_config.xml --create=true --load=true --execute=true
       - name: Wikipedia
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b wikipedia -c config/mysql/sample_wikipedia_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b wikipedia -c config/mysql/sample_wikipedia_config.xml --create=true --load=true --execute=true
       - name: YCSB
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         env:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           mysql -h127.0.0.1 -P$MYSQL_PORT -uadmin -ppassword -e "DROP DATABASE IF EXISTS oltpbench; CREATE DATABASE oltpbench"
-          java -jar oltpbench2.jar -b ycsb -c config/mysql/sample_ycsb_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b ycsb -c config/mysql/sample_ycsb_config.xml --create=true --load=true --execute=true
       - name: Aggregate result summaries.
         if: ${{ github.event_name == 'pull_request_target' }}
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           SUMMARIES=$(python3 scripts/result_aggregator.py results/)
           echo 'COMMENT_MESSAGE<<EOF' >> $GITHUB_ENV
@@ -249,115 +249,115 @@ jobs:
       - name: Extract TGZ artifact in target/.
         working-directory: target
         run: |
-          tar xvzf oltpbench2-$OLTPBENCH_POM_VERSION.tgz
-          mv oltpbench2-$OLTPBENCH_POM_VERSION oltpbench2-extracted
+          tar xvzf benchbase-$POM_VERSION.tgz
+          mv benchbase-$POM_VERSION benchbase-extracted
       - name: AuctionMark
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b auctionmark -c config/postgres/sample_auctionmark_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b auctionmark -c config/postgres/sample_auctionmark_config.xml --create=true --load=true --execute=true
       - name: CH-benCHmark
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b tpcc -c config/postgres/sample_tpcc_config.xml --create=true --load=true
-          java -jar oltpbench2.jar -b chbenchmark -c config/postgres/sample_chbenchmark_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b tpcc -c config/postgres/sample_tpcc_config.xml --create=true --load=true
+          java -jar benchbase.jar -b chbenchmark -c config/postgres/sample_chbenchmark_config.xml --create=true --load=true --execute=true
       - name: Epinions.com
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b epinions -c config/postgres/sample_epinions_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b epinions -c config/postgres/sample_epinions_config.xml --create=true --load=true --execute=true
       - name: hyadapt
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b hyadapt -c config/postgres/sample_hyadapt_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b hyadapt -c config/postgres/sample_hyadapt_config.xml --create=true --load=true --execute=true
       - name: noop
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b noop -c config/postgres/sample_noop_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b noop -c config/postgres/sample_noop_config.xml --create=true --load=true --execute=true
       - name: Resource Stresser
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b resourcestresser -c config/postgres/sample_resourcestresser_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b resourcestresser -c config/postgres/sample_resourcestresser_config.xml --create=true --load=true --execute=true
       - name: SEATS
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b seats -c config/postgres/sample_seats_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b seats -c config/postgres/sample_seats_config.xml --create=true --load=true --execute=true
       - name: SIBench
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b sibench -c config/postgres/sample_sibench_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b sibench -c config/postgres/sample_sibench_config.xml --create=true --load=true --execute=true
       - name: SmallBank
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b smallbank -c config/postgres/sample_smallbank_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b smallbank -c config/postgres/sample_smallbank_config.xml --create=true --load=true --execute=true
       - name: TATP
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b tatp -c config/postgres/sample_tatp_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b tatp -c config/postgres/sample_tatp_config.xml --create=true --load=true --execute=true
       - name: TPC-C
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b tpcc -c config/postgres/sample_tpcc_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b tpcc -c config/postgres/sample_tpcc_config.xml --create=true --load=true --execute=true
       # TPC-DS does not have a sample configuration available right now.
       # - name: TPC-DS
-      #   working-directory: target/oltpbench2-extracted
+      #   working-directory: target/benchbase-extracted
       #   run: |
       #     PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
       #     PGPASSWORD=password createdb -h localhost -U admin oltpbench
-      #     java -jar oltpbench2.jar -b tpcds -c config/postgres/sample_tpcds_config.xml --create=true --load=true --execute=true
+      #     java -jar benchbase.jar -b tpcds -c config/postgres/sample_tpcds_config.xml --create=true --load=true --execute=true
       - name: TPC-H
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b tpch -c config/postgres/sample_tpch_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b tpch -c config/postgres/sample_tpch_config.xml --create=true --load=true --execute=true
       - name: Twitter
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b twitter -c config/postgres/sample_twitter_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b twitter -c config/postgres/sample_twitter_config.xml --create=true --load=true --execute=true
       - name: Voter
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b voter -c config/postgres/sample_voter_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b voter -c config/postgres/sample_voter_config.xml --create=true --load=true --execute=true
       - name: Wikipedia
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b wikipedia -c config/postgres/sample_wikipedia_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b wikipedia -c config/postgres/sample_wikipedia_config.xml --create=true --load=true --execute=true
       - name: YCSB
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           PGPASSWORD=password dropdb -h localhost -U admin oltpbench --if-exists
           PGPASSWORD=password createdb -h localhost -U admin oltpbench
-          java -jar oltpbench2.jar -b ycsb -c config/postgres/sample_ycsb_config.xml --create=true --load=true --execute=true
+          java -jar benchbase.jar -b ycsb -c config/postgres/sample_ycsb_config.xml --create=true --load=true --execute=true
       - name: Aggregate result summaries.
         if: ${{ github.event_name == 'pull_request_target' }}
-        working-directory: target/oltpbench2-extracted
+        working-directory: target/benchbase-extracted
         run: |
           SUMMARIES=$(python3 scripts/result_aggregator.py results/)
           echo 'COMMENT_MESSAGE<<EOF' >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # BenchBase
 
-[![BenchBase (Java with Maven)](https://github.com/oltpbenchmark/oltpbench/actions/workflows/maven.yml/badge.svg?branch=oltpbench_tim)](https://github.com/oltpbenchmark/oltpbench/actions/workflows/maven.yml)
+[![BenchBase (Java with Maven)](https://github.com/cmu-db/benchbase/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/cmu-db/benchbase/actions/workflows/maven.yml)
 
-BenchBase (formerly [OLTPBench](https://github.com/oltpbenchmark/oltpbench/)) is a multi-threaded load generator for JDBC-enabled relational databases.
+BenchBase (formerly [OLTPBench](https://github.com/oltpbenchmark/oltpbench/)) is a Multi-DBMS SQL Benchmarking Framework via JDBC.
 
 **Table of Contents**
 
@@ -18,12 +18,10 @@ BenchBase (formerly [OLTPBench](https://github.com/oltpbenchmark/oltpbench/)) is
 
 ## Quickstart
 
-(TODO(WAN): new name new URL and also set to main)
-
 To clone and build BenchBase,
 
 ```bash
-git clone --single-branch --branch oltpbench_tim https://github.com/oltpbenchmark/oltpbench.git
+git clone --depth 1 https://github.com/cmu-db/benchbase.git
 cd oltpbench
 ./mvnw clean package
 ```
@@ -32,20 +30,20 @@ This produces artifacts in the `target` folder, which can be extracted,
 
 ```bash
 cd target
-tar xvzf oltpbench2-x-y-z.tgz # Change x-y-z appropriately.
-cd oltpbench2-x-y-z           # Change x-y-z appropriately.
+tar xvzf benchbase-x-y-z.tgz # Change x-y-z appropriately.
+cd benchbase-x-y-z           # Change x-y-z appropriately.
 ```
 
 Inside this folder, you can run BenchBase. For example, to execute the `tpcc` benchmark,
 
 ```bash
-java -jar oltpbench2.jar -b tpcc -c config/postgres/sample_tpcc_config.xml --create=true --load=true --execute=true
+java -jar benchbase.jar -b tpcc -c config/postgres/sample_tpcc_config.xml --create=true --load=true --execute=true
 ```
 
 A full list of options can be displayed,
 
 ```bash
-java -jar oltpbench2.jar -h
+java -jar benchbase.jar -h
 ```
 
 ---
@@ -61,6 +59,7 @@ variable mixture load against any JDBC-enabled relational database. The framewor
 features, e.g., per-transaction-type latency and throughput logs.
 
 The BenchBase framework has the following benchmarks:
+
 (TODO(WAN): Get permission to migrate/copy Tim's wiki for benchmark descriptions)
 
 * [AuctionMark](https://github.com/timveil-cockroach/oltpbench/wiki/AuctionMark)
@@ -96,25 +95,25 @@ Run the following command to build the distribution:
 
 The following files will be placed in the `./target` folder:
 
-* `oltpbench2-x.y.z.tgz`
-* `oltpbench2-x.y.z.zip`
+* `benchbase-x.y.z.tgz`
+* `benchbase-x.y.z.zip`
 
 ### How to Run
-Once you build and unpack the distribution, you can run `oltpbench2` just like any other executable jar.  The following examples assume you are running from the root of the expanded `.zip` or `.tgz` distribution.  If you attempt to run `oltpbench2` outside of the distribution structure you may encounter a variety of errors including `java.lang.NoClassDefFoundError`.
+Once you build and unpack the distribution, you can run `benchbase` just like any other executable jar.  The following examples assume you are running from the root of the expanded `.zip` or `.tgz` distribution.  If you attempt to run `benchbase` outside of the distribution structure you may encounter a variety of errors including `java.lang.NoClassDefFoundError`.
 
 To bring up help contents:
 ```bash
-java -jar oltpbench2.jar -h
+java -jar benchbase.jar -h
 ```
 
 To execute the `tpcc` benchmark:
 ```bash
-java -jar oltpbench2.jar -b tpcc -c config/postgres/sample_tpcc_config.xml --create=true --load=true --execute=true
+java -jar benchbase.jar -b tpcc -c config/postgres/sample_tpcc_config.xml --create=true --load=true --execute=true
 ```
 
 For composite benchmarks like `chbenchmark`, which require multiple schemas to be created and loaded, you can provide a comma separated list: `
 ```bash
-java -jar oltpbench2.jar -b tpcc,chbenchmark -c config/postgres/sample_chbenchmark_config.xml --create=true --load=true --execute=true
+java -jar benchbase.jar -b tpcc,chbenchmark -c config/postgres/sample_chbenchmark_config.xml --create=true --load=true --execute=true
 ```
 
 The following options are provided:

--- a/config/cockroachdb/sample_auctionmark_config.xml
+++ b/config/cockroachdb/sample_auctionmark_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=auctionmark&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=auctionmark&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_chbenchmark_config.xml
+++ b/config/cockroachdb/sample_chbenchmark_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=chbenchmark-mixed&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=chbenchmark-mixed&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_epinions_config.xml
+++ b/config/cockroachdb/sample_epinions_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=epinions&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=epinions&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_hyadapt_config.xml
+++ b/config/cockroachdb/sample_hyadapt_config.xml
@@ -3,7 +3,7 @@
 
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=hyadapt&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=hyadapt&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_noop_config.xml
+++ b/config/cockroachdb/sample_noop_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=noop&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=noop&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_resourcestresser_config.xml
+++ b/config/cockroachdb/sample_resourcestresser_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=resourcestresser&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=resourcestresser&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_seats_config.xml
+++ b/config/cockroachdb/sample_seats_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=seats&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=seats&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_sibench_config.xml
+++ b/config/cockroachdb/sample_sibench_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=sibench&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=sibench&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_smallbank_config.xml
+++ b/config/cockroachdb/sample_smallbank_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=smallbank&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=smallbank&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_tatp_config.xml
+++ b/config/cockroachdb/sample_tatp_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=tatp&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=tatp&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_tpcc_config.xml
+++ b/config/cockroachdb/sample_tpcc_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=tpcc&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=tpcc&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_tpch_config.xml
+++ b/config/cockroachdb/sample_tpch_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=tpch&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=tpch&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_twitter_config.xml
+++ b/config/cockroachdb/sample_twitter_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=twitter&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=twitter&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_voter_config.xml
+++ b/config/cockroachdb/sample_voter_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=voter&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=voter&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_wikipedia_config.xml
+++ b/config/cockroachdb/sample_wikipedia_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=wikipedia&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=wikipedia&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/cockroachdb/sample_ycsb_config.xml
+++ b/config/cockroachdb/sample_ycsb_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>COCKROACHDB</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:26257/oltpbench?sslmode=disable&amp;ApplicationName=ycsb&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=ycsb&amp;reWriteBatchedInserts=true</url>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_auctionmark_config.xml
+++ b/config/mysql/sample_auctionmark_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_chbenchmark_config.xml
+++ b/config/mysql/sample_chbenchmark_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_epinions_config.xml
+++ b/config/mysql/sample_epinions_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_hyadapt_config.xml
+++ b/config/mysql/sample_hyadapt_config.xml
@@ -3,7 +3,7 @@
 
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_noop_config.xml
+++ b/config/mysql/sample_noop_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_resourcestresser_config.xml
+++ b/config/mysql/sample_resourcestresser_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_seats_config.xml
+++ b/config/mysql/sample_seats_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_sibench_config.xml
+++ b/config/mysql/sample_sibench_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_smallbank_config.xml
+++ b/config/mysql/sample_smallbank_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_tatp_config.xml
+++ b/config/mysql/sample_tatp_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_tpcc_config.xml
+++ b/config/mysql/sample_tpcc_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_tpch_config.xml
+++ b/config/mysql/sample_tpch_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true&amp;allowLoadLocalInfile=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true&amp;allowLoadLocalInfile=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_twitter_config.xml
+++ b/config/mysql/sample_twitter_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_voter_config.xml
+++ b/config/mysql/sample_voter_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_wikipedia_config.xml
+++ b/config/mysql/sample_wikipedia_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/mysql/sample_ycsb_config.xml
+++ b/config/mysql/sample_ycsb_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>MYSQL</type>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:3306/oltpbench?rewriteBatchedStatements=true</url>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_auctionmark_config.xml
+++ b/config/postgres/sample_auctionmark_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=auctionmark&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=auctionmark&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_chbenchmark_config.xml
+++ b/config/postgres/sample_chbenchmark_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=chbenchmark&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=chbenchmark&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_epinions_config.xml
+++ b/config/postgres/sample_epinions_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=epinions&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=epinions&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_hyadapt_config.xml
+++ b/config/postgres/sample_hyadapt_config.xml
@@ -3,7 +3,7 @@
 
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=hyadapt&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=hyadapt&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_noop_config.xml
+++ b/config/postgres/sample_noop_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=noop&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=noop&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_resourcestresser_config.xml
+++ b/config/postgres/sample_resourcestresser_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=resourcestresser&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=resourcestresser&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_seats_config.xml
+++ b/config/postgres/sample_seats_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=seats&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=seats&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_sibench_config.xml
+++ b/config/postgres/sample_sibench_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=sibench&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=sibench&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_smallbank_config.xml
+++ b/config/postgres/sample_smallbank_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=smallbank&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=smallbank&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_tatp_config.xml
+++ b/config/postgres/sample_tatp_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=tatp&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=tatp&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_tpcc_config.xml
+++ b/config/postgres/sample_tpcc_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=tpcc&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=tpcc&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_tpch_config.xml
+++ b/config/postgres/sample_tpch_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=tpch&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=tpch&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_twitter_config.xml
+++ b/config/postgres/sample_twitter_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=twitter&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=twitter&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_voter_config.xml
+++ b/config/postgres/sample_voter_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=voter&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=voter&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_wikipedia_config.xml
+++ b/config/postgres/sample_wikipedia_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=wikipedia&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=wikipedia&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/config/postgres/sample_ycsb_config.xml
+++ b/config/postgres/sample_ycsb_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>POSTGRES</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/oltpbench?sslmode=disable&amp;ApplicationName=ycsb&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=ycsb&amp;reWriteBatchedInserts=true</url>
     <username>admin</username>
     <password>password</password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>

--- a/docker/cockroach-latest/docker-compose.yml
+++ b/docker/cockroach-latest/docker-compose.yml
@@ -6,13 +6,13 @@ services:
     container_name: crdb-0
     hostname: crdb-0
     image: cockroachdb/cockroach:latest
-    command: start-single-node --cluster-name=oltpbench2 --logtostderr=WARNING --log-file-verbosity=WARNING --insecure --max-sql-memory=4GB
+    command: start-single-node --cluster-name=benchbase --logtostderr=WARNING --log-file-verbosity=WARNING --insecure --max-sql-memory=4GB
 
   crdb-1:
     container_name: crdb-1
     hostname: crdb-1
     image: cockroachdb/cockroach:latest
-    command: start --cluster-name=oltpbench2 --logtostderr=WARNING --log-file-verbosity=WARNING --insecure --max-sql-memory=4GB --join=crdb-0
+    command: start --cluster-name=benchbase --logtostderr=WARNING --log-file-verbosity=WARNING --insecure --max-sql-memory=4GB --join=crdb-0
     depends_on:
       - crdb-0
 
@@ -20,7 +20,7 @@ services:
     container_name: crdb-2
     hostname: crdb-2
     image: cockroachdb/cockroach:latest
-    command: start --cluster-name=oltpbench2 --logtostderr=WARNING --log-file-verbosity=WARNING --insecure --max-sql-memory=4GB --join=crdb-0
+    command: start --cluster-name=benchbase --logtostderr=WARNING --log-file-verbosity=WARNING --insecure --max-sql-memory=4GB --join=crdb-0
     depends_on:
       - crdb-0
 

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ivy-module version="1.0">
 	<info organisation="com.oltpbenchmark"
-		module="oltpbench"
+		module="benchbase"
 		revision="1.0"
 		status="integration"
 		publication="20190513211538"
@@ -16,7 +16,7 @@
 		<conf name="system" visibility="public" description="this scope is similar to provided except that you have to provide the JAR which contains it explicitly. The artifact is always available and is not looked up in a repository."/>
 	</configurations>
 	<publications>
-		<artifact name="oltpbench" type="jar" ext="jar" conf="master"/>
+		<artifact name="benchbase" type="jar" ext="jar" conf="master"/>
 	</publications>
 	<dependencies>
       <!-- JDBC Drivers -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,18 +4,11 @@
 
 
     <groupId>com.oltpbenchmark</groupId>
-    <artifactId>oltpbench2</artifactId>
-    <version>20.1.3-SNAPSHOT</version>
-    <name>OLTP-Bench II</name>
-    <description>OLTP-Bench II is a database benchmarking framework inspired by http://oltpbenchmark.com/
-    </description>
-    <url>https://github.com/timveil-cockroach/oltpbench</url>
-    <contributors>
-        <contributor>
-            <name>Tim Veil</name>
-            <url>https://github.com/timveil</url>
-        </contributor>
-    </contributors>
+    <artifactId>benchbase</artifactId>
+    <version>2021</version>
+    <name>BenchBase</name>
+    <description>BenchBase is a Multi-DBMS SQL Benchmarking Framework via JDBC https://github.com/cmu-db/benchbase</description>
+    <url>https://github.com/cmu-db/benchbase</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -25,17 +18,17 @@
     </properties>
 
     <scm>
-        <connection>scm:git:git@github.com:timveil-cockroach/oltpbench.git</connection>
-        <url>https://github.com/timveil-cockroach/oltpbench</url>
-        <developerConnection>scm:git:git@github.com:timveil-cockroach/oltpbench.git</developerConnection>
+        <connection>scm:git:git@github.com:cmu-db/benchbase.git</connection>
+        <url>https://github.com/cmu-db/benchbase</url>
+        <developerConnection>scm:git:git@github.com:cmu-db/benchbase.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>
         <repository>
             <id>github</id>
-            <name>GitHub timveil-cockroach/oltpbench Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/timveil-cockroach/oltpbench</url>
+            <name>GitHub cmu-db/benchbase Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/cmu-db/benchbase</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
This pull request completes the move from the old oltpbench repo (https://github.com/oltpbenchmark/oltpbench) to the new BenchBase repo.

- Rename default testing databases from `oltpbench` to `benchbase`.
- Update GitHub Actions maven.yml.
- Update README.
- Modify CalVer versioning scheme to just be benchbase-YEAR, e.g., benchbase-2021. We can make it more granular again (previously 20.1.3-SNAPSHOT) if necessary.