### PR TITLE
Fix NoOp benchmark execution.

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/noop/procedures/NoOp.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/noop/procedures/NoOp.java
@@ -41,9 +41,7 @@ public class NoOp extends Procedure {
     public final SQLStmt noopStmt = new SQLStmt(";");
 
     public void run(Connection conn) {
-        try (PreparedStatement stmt = this.getPreparedStatement(conn, noopStmt);
-             ResultSet r = stmt.executeQuery()) {
-
+        try (PreparedStatement stmt = this.getPreparedStatement(conn, noopStmt)) {
             // IMPORTANT:
             // Some DBMSs will throw an exception here when you execute
             // a query that does not return a result. So we are just
@@ -52,9 +50,12 @@ public class NoOp extends Procedure {
             // exception here and check whether it is actually working
             // correctly.
 
-
-            while (r.next()) {
-                // Do nothing
+            if (stmt.execute()) {
+                ResultSet r = stmt.getResultSet();
+                while (r.next()) {
+                    // Do nothing
+                }
+                r.close();
             }
 
         } catch (Exception ex) {


### PR DESCRIPTION
This is a direct port of https://github.com/oltpbenchmark/oltpbench/pull/388
which was opened against OLTPBench after the work on BenchBase had begun.

Description from the original PR by @michaelfruth

---

The benchmark always ran through the catch-block, because
stmt.executeQuery() expects a result. The single query ';' does not
return anything at all.

Now, the query is executed and if there is a result, than it is
processed as before.

Tested with PostgreSQL 13.

See also: https://github.com/oltpbenchmark/oltpbench/pull/229