### PR TITLE
Reduce verbosity of HikariPool logger (INFO to WARN).

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -17,7 +17,7 @@ log4j.logger.com.oltpbenchmark.api.Procedure=INFO
 log4j.logger.com.oltpbenchmark.catalog.Catalog=INFO
 log4j.logger.com.oltpbenchmark.util.ThreadUtil=INFO
 log4j.logger.com.zaxxer.hikari.HikariConfig=INFO
-log4j.logger.com.zaxxer.hikari.pool.HikariPool=INFO
+log4j.logger.com.zaxxer.hikari.pool.HikariPool=WARN
 
 ## to see UserAbortException messages set this logger to DEBUG
 log4j.logger.com.oltpbenchmark.api.ABORT_LOG=WARN


### PR DESCRIPTION
The new version of HikariCP introduced by https://github.com/cmu-db/benchbase/pull/1 is very noisy.

Excerpt from tests:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.039 sec
Running com.oltpbenchmark.benchmarks.twitter.TestTwitterBenchmark
[INFO ] 2021-08-09 16:30:21,662 [main]  com.zaxxer.hikari.pool.HikariPool checkFailFast - HikariPool-100 - Added connection org.hsqldb.jdbc.JDBCConnection@6e0dec27
[INFO ] 2021-08-09 16:30:21,677 [main]  com.zaxxer.hikari.pool.HikariPool checkFailFast - HikariPool-101 - Added connection org.hsqldb.jdbc.JDBCConnection@4199761d
[INFO ] 2021-08-09 16:30:21,697 [main]  com.zaxxer.hikari.pool.HikariPool checkFailFast - HikariPool-102 - Added connection org.hsqldb.jdbc.JDBCConnection@738ae785
[INFO ] 2021-08-09 16:30:21,710 [main]  com.zaxxer.hikari.pool.HikariPool checkFailFast - HikariPool-103 - Added connection org.hsqldb.jdbc.JDBCConnection@3b6c55b6
[INFO ] 2021-08-09 16:30:21,723 [main]  com.zaxxer.hikari.pool.HikariPool checkFailFast - HikariPool-104 - Added connection org.hsqldb.jdbc.JDBCConnection@2c989d82
[INFO ] 2021-08-09 16:30:21,736 [main]  com.zaxxer.hikari.pool.HikariPool checkFailFast - HikariPool-105 - Added connection org.hsqldb.jdbc.JDBCConnection@1174ff02
```