### PR TITLE
Add SNAPSHOT to version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.oltpbenchmark</groupId>
     <artifactId>benchbase</artifactId>
-    <version>2021</version>
+    <version>2021-SNAPSHOT</version>
     <name>BenchBase</name>
     <description>BenchBase is a Multi-DBMS SQL Benchmarking Framework via JDBC https://github.com/cmu-db/benchbase</description>
     <url>https://github.com/cmu-db/benchbase</url>


### PR DESCRIPTION
It turns out that this is needed for `./mvnw -B release:prepare` to function properly.