### PR TITLE
Port AuctionMark fixes for large scalefactor.

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkLoader.java
@@ -606,7 +606,7 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
 
         private final LinkedBlockingDeque<T> queue = new LinkedBlockingDeque<>();
         private T current;
-        private short currentCounter;
+        private int currentCounter;
         private boolean stop = false;
         private final String sourceTableName;
 
@@ -615,9 +615,9 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
             this.sourceTableName = sourceTableName;
         }
 
-        protected abstract short getElementCounter(T t);
+        protected abstract int getElementCounter(T t);
 
-        protected abstract int populateRow(T t, Object[] row, short remaining);
+        protected abstract int populateRow(T t, Object[] row, int remaining);
 
         public void stopWhenEmpty() {
             if (LOG.isDebugEnabled()) {
@@ -962,12 +962,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        protected short getElementCounter(UserId user_id) {
-            return (short) (randomNumUserAttributes.nextInt());
+        protected int getElementCounter(UserId user_id) {
+            return randomNumUserAttributes.nextInt();
         }
 
         @Override
-        protected int populateRow(UserId user_id, Object[] row, short remaining) {
+        protected int populateRow(UserId user_id, Object[] row, int remaining) {
             int col = 0;
 
             // UA_ID
@@ -1000,8 +1000,8 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        protected short getElementCounter(UserId user_id) {
-            return (short) (user_id.getItemCount());
+        protected int getElementCounter(UserId user_id) {
+            return user_id.getItemCount();
         }
 
         @Override
@@ -1014,7 +1014,7 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        protected int populateRow(UserId seller_id, Object[] row, short remaining) {
+        protected int populateRow(UserId seller_id, Object[] row, int remaining) {
             int col = 0;
 
             ItemId itemId = new ItemId(seller_id, remaining);
@@ -1035,8 +1035,8 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
 
 
             // Calculate the number of bids and watches for this item
-            short numBids = (short) p.first.nextInt();
-            short numWatches = (short) p.second.nextInt();
+            int numBids = p.first.nextInt();
+            int numWatches = p.second.nextInt();
 
             // Create the ItemInfo object that we will use to cache the local data
 
@@ -1139,12 +1139,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
+        public int getElementCounter(LoaderItemInfo itemInfo) {
             return itemInfo.getNumImages();
         }
 
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, int remaining) {
             int col = 0;
 
             // II_ID
@@ -1168,12 +1168,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
+        public int getElementCounter(LoaderItemInfo itemInfo) {
             return itemInfo.getNumAttributes();
         }
 
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, int remaining) {
             int col = 0;
             GlobalAttributeValueId gav_id = profile.getRandomGlobalAttributeValue();
 
@@ -1203,12 +1203,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
-            return (itemInfo.getPurchaseDate() != null ? itemInfo.getNumComments() : 0);
+        public int getElementCounter(LoaderItemInfo itemInfo) {
+            return itemInfo.getPurchaseDate() != null ? itemInfo.getNumComments() : 0;
         }
 
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, int remaining) {
             int col = 0;
 
             // IC_ID
@@ -1254,12 +1254,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
-            return ((short) itemInfo.getNumBids());
+        public int getElementCounter(LoaderItemInfo itemInfo) {
+            return ((int) itemInfo.getNumBids());
         }
 
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, int remaining) {
             int col = 0;
 
 
@@ -1354,12 +1354,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
-            return (short) (itemInfo.getBidCount() > 0 ? 1 : 0);
+        public int getElementCounter(LoaderItemInfo itemInfo) {
+            return itemInfo.getBidCount() > 0 ? 1 : 0;
         }
 
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, int remaining) {
             int col = 0;
             LoaderItemInfo.Bid bid = itemInfo.getLastBid();
 
@@ -1393,12 +1393,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
-            return (short) (itemInfo.getBidCount() > 0 && itemInfo.getPurchaseDate() != null ? 1 : 0);
+        public int getElementCounter(LoaderItemInfo itemInfo) {
+            return itemInfo.getBidCount() > 0 && itemInfo.getPurchaseDate() != null ? 1 : 0;
         }
 
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, int remaining) {
             int col = 0;
             LoaderItemInfo.Bid bid = itemInfo.getLastBid();
 
@@ -1438,12 +1438,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        protected short getElementCounter(LoaderItemInfo.Bid bid) {
-            return (short) ((bid.isBuyer_feedback() ? 1 : 0) + (bid.isSeller_feedback() ? 1 : 0));
+        protected int getElementCounter(LoaderItemInfo.Bid bid) {
+            return (bid.isBuyer_feedback() ? 1 : 0) + (bid.isSeller_feedback() ? 1 : 0);
         }
 
         @Override
-        protected int populateRow(LoaderItemInfo.Bid bid, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo.Bid bid, Object[] row, int remaining) {
             int col = 0;
 
             boolean is_buyer = false;
@@ -1482,12 +1482,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
-            return (short) (itemInfo.getBidCount() > 0 && itemInfo.getPurchaseDate() != null ? 1 : 0);
+        public int getElementCounter(LoaderItemInfo itemInfo) {
+            return itemInfo.getBidCount() > 0 && itemInfo.getPurchaseDate() != null ? 1 : 0;
         }
 
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, int remaining) {
             int col = 0;
             LoaderItemInfo.Bid bid = itemInfo.getLastBid();
 
@@ -1525,12 +1525,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
-            return (itemInfo.getNumWatches());
+        public int getElementCounter(LoaderItemInfo itemInfo) {
+            return itemInfo.getNumWatches();
         }
 
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, int remaining) {
             int col = 0;
 
             // Make it more likely that a user that has bid on an item is watching it

--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/util/ItemId.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/util/ItemId.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 public class ItemId extends CompositeId implements Comparable<ItemId> {
 
     private static final int[] COMPOSITE_BITS = {
-            40, // SELLER_ID
+            44, // SELLER_ID
             16, // ITEM_CTR
     };
     private static final long[] COMPOSITE_POWS = compositeBitsPreCompute(COMPOSITE_BITS);

--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/util/LoaderItemInfo.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/util/LoaderItemInfo.java
@@ -35,7 +35,7 @@ public class LoaderItemInfo extends ItemInfo {
     private short numImages;
     private short numAttributes;
     private short numComments;
-    private short numWatches;
+    private int numWatches;
     private Timestamp startDate;
     private Timestamp purchaseDate;
     private float initialPrice;
@@ -78,11 +78,11 @@ public class LoaderItemInfo extends ItemInfo {
         this.numComments = numComments;
     }
 
-    public short getNumWatches() {
+    public int getNumWatches() {
         return numWatches;
     }
 
-    public void setNumWatches(short numWatches) {
+    public void setNumWatches(int numWatches) {
         this.numWatches = numWatches;
     }
 

--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/util/UserId.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/util/UserId.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 public class UserId extends CompositeId implements Comparable<UserId> {
 
     private static final int[] COMPOSITE_BITS = {
-            16, // ITEM_COUNT
+            20, // ITEM_COUNT
             24, // OFFSET
     };
     private static final long[] COMPOSITE_POWS = compositeBitsPreCompute(COMPOSITE_BITS);

--- a/src/main/java/com/oltpbenchmark/util/CompositeId.java
+++ b/src/main/java/com/oltpbenchmark/util/CompositeId.java
@@ -24,6 +24,7 @@ import org.json.JSONObject;
 import org.json.JSONStringer;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Pack multiple values into a single long using bit-shifting
@@ -50,9 +51,16 @@ public abstract class CompositeId implements JSONSerializable {
         for (int i = 0; i < values.length; i++) {
             long max_value = offset_pows[i];
 
-            assert (values[i] < max_value) :
-                    String.format("%s value at position %d is %d. Max value is %d\n%s",
-                            this.getClass().getSimpleName(), i, values[i], max_value, this);
+            if (values[i] < 0) {
+                throw new IllegalArgumentException(String.format("%s value at position %d is %d %s",
+                        this.getClass().getSimpleName(), i,
+                        values[i], Arrays.toString(values)));
+            }
+            if (values[i] >= max_value) {
+                throw new IllegalArgumentException(String.format("%s value at position %d is %d. Max value is %d\n",
+                        this.getClass().getSimpleName(), i,
+                        values[i], max_value));
+            }
 
             id = (i == 0 ? values[i] : id | values[i] << offset);
             offset += offset_bits[i];

--- a/src/test/java/com/oltpbenchmark/benchmarks/auctionmark/util/TestUserIdGenerator.java
+++ b/src/test/java/com/oltpbenchmark/benchmarks/auctionmark/util/TestUserIdGenerator.java
@@ -40,7 +40,6 @@ import com.oltpbenchmark.util.RandomDistribution.Zipf;
 import com.oltpbenchmark.util.RandomGenerator;
 
 /**
- *
  * @author pavlo
  */
 public class TestUserIdGenerator extends TestCase {
@@ -57,13 +56,13 @@ public class TestUserIdGenerator extends TestCase {
     private final Histogram<Long> users_per_item_count = new Histogram<Long>();
 
 
-	@Before
-	public void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         for (long i = 0; i < NUM_USERS; i++) {
-            this.users_per_item_count.put((long)randomNumItems.nextInt());
+            this.users_per_item_count.put((long) randomNumItems.nextInt());
         } // FOR
         assertEquals(NUM_USERS, this.users_per_item_count.getSampleCount());
-	}
+    }
 
     /**
      * testCheckClient
@@ -102,18 +101,18 @@ public class TestUserIdGenerator extends TestCase {
         } // FOR
     }
 
-	/**
-	 * testSeekToPosition
-	 */
-	public void testSeekToPosition() throws Exception {
-	    UserIdGenerator generator = new UserIdGenerator(users_per_item_count, 1);
-	    final int num_users = (int)(generator.getTotalUsers()-1);
+    /**
+     * testSeekToPosition
+     */
+    public void testSeekToPosition() throws Exception {
+        UserIdGenerator generator = new UserIdGenerator(users_per_item_count, 1);
+        final int num_users = (int) (generator.getTotalUsers() - 1);
 
-	    int itemCount = rand.nextInt(users_per_item_count.getMaxValue().intValue()-1);
-	    generator.setCurrentItemCount(itemCount);
+        int itemCount = rand.nextInt(users_per_item_count.getMaxValue().intValue() - 1);
+        generator.setCurrentItemCount(itemCount);
 //	    System.err.println("itemCount = " + itemCount);
 
-	    int cur_position = generator.getCurrentPosition();
+        int cur_position = generator.getCurrentPosition();
         int new_position = rand.number(cur_position, num_users);
 //        System.err.println(users_per_item_count);
 //        System.err.println("cur_position = " + cur_position);
@@ -131,7 +130,7 @@ public class TestUserIdGenerator extends TestCase {
         assertNotNull(user_id);
 //        System.err.println(user_id);
         assertEquals(expected, user_id);
-	}
+    }
 
     /**
      * testSeekToPositionSameUserId
@@ -139,7 +138,7 @@ public class TestUserIdGenerator extends TestCase {
     public void testSeekToPositionClientId() throws Exception {
         int num_clients = 10;
         UserIdGenerator generator = new UserIdGenerator(users_per_item_count, num_clients);
-        final int num_users = (int)(generator.getTotalUsers()-1);
+        final int num_users = (int) (generator.getTotalUsers() - 1);
 
         Map<Integer, UserId> expectedIds = new TreeMap<Integer, UserId>();
         while (generator.hasNext()) {
@@ -173,67 +172,67 @@ public class TestUserIdGenerator extends TestCase {
 
     }
 
-	/**
-	 * testAllUsers
-	 */
-	public void testAllUsers() throws Exception {
-	    UserIdGenerator generator = new UserIdGenerator(users_per_item_count, NUM_CLIENTS);
-	    Set<UserId> seen = new HashSet<UserId>();
-	    assert(generator.hasNext());
-	    for (UserId u_id : CollectionUtil.iterable(generator)) {
-	        assertNotNull(u_id);
-	        assert(seen.contains(u_id) == false) : "Duplicate " + u_id;
-	        seen.add(u_id);
+    /**
+     * testAllUsers
+     */
+    public void testAllUsers() throws Exception {
+        UserIdGenerator generator = new UserIdGenerator(users_per_item_count, NUM_CLIENTS);
+        Set<UserId> seen = new HashSet<UserId>();
+        assert (generator.hasNext());
+        for (UserId u_id : CollectionUtil.iterable(generator)) {
+            assertNotNull(u_id);
+            assert (seen.contains(u_id) == false) : "Duplicate " + u_id;
+            seen.add(u_id);
 //	        System.err.println(u_id);
-	    } // FOR
-	    assertEquals(NUM_USERS, seen.size());
-	}
+        } // FOR
+        assertEquals(NUM_USERS, seen.size());
+    }
 
-	/**
-	 * testPerClient
-	 */
-	public void testPerClient() throws Exception {
-	    Histogram<Integer> clients_h = new Histogram<Integer>();
-	    Set<UserId> all_seen = new HashSet<UserId>();
-	    for (int client = 0; client < NUM_CLIENTS; client++) {
-    	    UserIdGenerator generator = new UserIdGenerator(users_per_item_count, NUM_CLIENTS, client);
+    /**
+     * testPerClient
+     */
+    public void testPerClient() throws Exception {
+        Histogram<Integer> clients_h = new Histogram<Integer>();
+        Set<UserId> all_seen = new HashSet<UserId>();
+        for (int client = 0; client < NUM_CLIENTS; client++) {
+            UserIdGenerator generator = new UserIdGenerator(users_per_item_count, NUM_CLIENTS, client);
             Set<UserId> seen = new HashSet<UserId>();
-            assert(generator.hasNext());
+            assert (generator.hasNext());
             for (UserId u_id : CollectionUtil.iterable(generator)) {
                 assertNotNull(u_id);
-                assert(seen.contains(u_id) == false) : "Duplicate " + u_id;
-                assert(all_seen.contains(u_id) == false) : "Duplicate " + u_id;
+                assert (seen.contains(u_id) == false) : "Duplicate " + u_id;
+                assert (all_seen.contains(u_id) == false) : "Duplicate " + u_id;
                 seen.add(u_id);
                 all_seen.add(u_id);
             } // FOR
             assertNotSame(Integer.toString(client), NUM_USERS, seen.size());
             assertFalse(Integer.toString(client), seen.isEmpty());
             clients_h.put(client, seen.size());
-	    } // FOR
-	    assertEquals(NUM_USERS, all_seen.size());
+        } // FOR
+        assertEquals(NUM_USERS, all_seen.size());
 
-	    // Make sure that they all have the same number of UserIds
-	    Integer last_cnt = null;
-	    for (Integer client : clients_h.values()) {
-	        if (last_cnt != null) {
-	            assertEquals(client.toString(), last_cnt, clients_h.get(client));
-	        }
-	        last_cnt = clients_h.get(client);
-	    } // FOR
+        // Make sure that they all have the same number of UserIds
+        Integer last_cnt = null;
+        for (Integer client : clients_h.values()) {
+            if (last_cnt != null) {
+                assertEquals(client.toString(), last_cnt, clients_h.get(client));
+            }
+            last_cnt = clients_h.get(client);
+        } // FOR
 //	    System.err.println(clients_h);
-	}
+    }
 
     /**
      * testSingleClient
      */
-	public void testSingleClient() throws Exception {
+    public void testSingleClient() throws Exception {
         // First create a UserIdGenerator for all clients and get
         // the set of all the UserIds that we expect
         UserIdGenerator generator = new UserIdGenerator(users_per_item_count, 1);
         Set<UserId> expected = new HashSet<UserId>();
         for (UserId u_id : CollectionUtil.iterable(generator)) {
             assertNotNull(u_id);
-            assert(expected.contains(u_id) == false) : "Duplicate " + u_id;
+            assert (expected.contains(u_id) == false) : "Duplicate " + u_id;
             expected.add(u_id);
         } // FOR
 
@@ -243,38 +242,38 @@ public class TestUserIdGenerator extends TestCase {
         generator = new UserIdGenerator(users_per_item_count, 1, 0);
         for (UserId u_id : CollectionUtil.iterable(generator)) {
             assertNotNull(u_id);
-            assert(actual.contains(u_id) == false) : "Duplicate " + u_id;
-            assert(expected.contains(u_id)) : "Unexpected " + u_id;
+            assert (actual.contains(u_id) == false) : "Duplicate " + u_id;
+            assert (expected.contains(u_id)) : "Unexpected " + u_id;
             actual.add(u_id);
         } // FOR
         assertEquals(expected.size(), actual.size());
     }
 
-	/**
-	 * testSetCurrentSize
-	 */
-	public void testSetCurrentSize() throws Exception {
-	    // First create a UserIdGenerator for a random ClientId and populate
-	    // the set of all the UserIds that we expect for this client
-	    Random rand = new Random();
-	    int client = rand.nextInt(NUM_CLIENTS);
-	    UserIdGenerator generator = new UserIdGenerator(users_per_item_count, NUM_CLIENTS, client);
-	    Set<UserId> seen = new HashSet<UserId>();
-	    for (UserId u_id : CollectionUtil.iterable(generator)) {
+    /**
+     * testSetCurrentSize
+     */
+    public void testSetCurrentSize() throws Exception {
+        // First create a UserIdGenerator for a random ClientId and populate
+        // the set of all the UserIds that we expect for this client
+        Random rand = new Random();
+        int client = rand.nextInt(NUM_CLIENTS);
+        UserIdGenerator generator = new UserIdGenerator(users_per_item_count, NUM_CLIENTS, client);
+        Set<UserId> seen = new HashSet<UserId>();
+        for (UserId u_id : CollectionUtil.iterable(generator)) {
             assertNotNull(u_id);
-            assert(seen.contains(u_id) == false) : "Duplicate " + u_id;
+            assert (seen.contains(u_id) == false) : "Duplicate " + u_id;
             seen.add(u_id);
         } // FOR
 
-	    // Now make sure that we always get back the same UserIds regardless of where
+        // Now make sure that we always get back the same UserIds regardless of where
         // we jump around with using setCurrentSize()
-	    for (int i = 0; i < 10; i++) {
-	        int size = rand.nextInt((int)(users_per_item_count.getMaxValue()+1));
-	        generator.setCurrentItemCount(size);
-	        for (UserId u_id : CollectionUtil.iterable(generator)) {
-	            assertNotNull(u_id);
-	            assert(seen.contains(u_id)) : "Unexpected " + u_id;
-	        } // FOR
-	    } // FOR
-	}
+        for (int i = 0; i < 10; i++) {
+            int size = rand.nextInt((int) (users_per_item_count.getMaxValue() + 1));
+            generator.setCurrentItemCount(size);
+            for (UserId u_id : CollectionUtil.iterable(generator)) {
+                assertNotNull(u_id);
+                assert (seen.contains(u_id)) : "Unexpected " + u_id;
+            } // FOR
+        } // FOR
+    }
 }

--- a/src/test/java/com/oltpbenchmark/benchmarks/auctionmark/util/TestUserIdGenerator.java
+++ b/src/test/java/com/oltpbenchmark/benchmarks/auctionmark/util/TestUserIdGenerator.java
@@ -206,7 +206,7 @@ public class TestUserIdGenerator extends TestCase {
                 seen.add(u_id);
                 all_seen.add(u_id);
             } // FOR
-            assertThat(Integer.toString(client), NUM_USERS, not(equalTo(seen.size())));
+            assertNotSame(Integer.toString(client), NUM_USERS, seen.size());
             assertFalse(Integer.toString(client), seen.isEmpty());
             clients_h.put(client, seen.size());
 	    } // FOR

--- a/src/test/java/com/oltpbenchmark/util/TestCompositeIdRange.java
+++ b/src/test/java/com/oltpbenchmark/util/TestCompositeIdRange.java
@@ -18,6 +18,7 @@
 package com.oltpbenchmark.util;
 
 import static org.junit.Assert.*;
+
 import org.junit.Test;
 
 import junit.framework.TestCase;
@@ -49,14 +50,14 @@ public class TestCompositeIdRange {
 
         @Override
         public void decode(long composite_id) {
-            long values[] = super.decode(composite_id, this.COMPOSITE_BITS,this. COMPOSITE_POWS);
-            this.field1 = (int)values[0];
-            this.field2 = (int)values[1];
+            long values[] = super.decode(composite_id, this.COMPOSITE_BITS, this.COMPOSITE_POWS);
+            this.field1 = (int) values[0];
+            this.field2 = (int) values[1];
         }
 
         @Override
         public long[] toArray() {
-            return (new long[]{ this.field1, this.field2 });
+            return (new long[]{this.field1, this.field2});
         }
 
         public int getField1() {
@@ -78,7 +79,7 @@ public class TestCompositeIdRange {
         assertEquals(packedLong.getField2(), packedLong2.getField2());
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testOutOfRange() {
         // Won't fit, we have allocated only 16 bits to field 1
         PackedLong packedLong = new PackedLong(Integer.MAX_VALUE, Integer.MAX_VALUE);

--- a/src/test/java/com/oltpbenchmark/util/TestCompositeIdRange.java
+++ b/src/test/java/com/oltpbenchmark/util/TestCompositeIdRange.java
@@ -1,0 +1,88 @@
+/******************************************************************************
+ *  Copyright 2021 by OLTPBenchmark Project                                   *
+ *                                                                            *
+ *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  you may not use this file except in compliance with the License.          *
+ *  You may obtain a copy of the License at                                   *
+ *                                                                            *
+ *    http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                            *
+ *  Unless required by applicable law or agreed to in writing, software       *
+ *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ *  See the License for the specific language governing permissions and       *
+ *  limitations under the License.                                            *
+ ******************************************************************************/
+
+
+package com.oltpbenchmark.util;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+public class TestCompositeIdRange {
+
+    public class PackedLong extends CompositeId {
+        protected final int COMPOSITE_BITS[] = {
+                16, // FIELD1
+                32, // FIELD2
+        };
+        protected final long COMPOSITE_POWS[] = compositeBitsPreCompute(COMPOSITE_BITS);
+
+        protected int field1;
+        protected int field2;
+
+        public PackedLong() {
+        }
+
+        public PackedLong(int field1, int field2) {
+            this.field1 = field1;
+            this.field2 = field2;
+        }
+
+        @Override
+        public long encode() {
+            return (this.encode(this.COMPOSITE_BITS, this.COMPOSITE_POWS));
+        }
+
+        @Override
+        public void decode(long composite_id) {
+            long values[] = super.decode(composite_id, this.COMPOSITE_BITS,this. COMPOSITE_POWS);
+            this.field1 = (int)values[0];
+            this.field2 = (int)values[1];
+        }
+
+        @Override
+        public long[] toArray() {
+            return (new long[]{ this.field1, this.field2 });
+        }
+
+        public int getField1() {
+            return this.field1;
+        }
+
+        public int getField2() {
+            return this.field2;
+        }
+    }
+
+    @Test
+    public void testPackOK() {
+        PackedLong packedLong = new PackedLong(1, 2);
+        long encodedLong = packedLong.encode();
+        PackedLong packedLong2 = new PackedLong();
+        packedLong2.decode(encodedLong);
+        assertEquals(packedLong.getField1(), packedLong2.getField1());
+        assertEquals(packedLong.getField2(), packedLong2.getField2());
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testOutOfRange() {
+        // Won't fit, we have allocated only 16 bits to field 1
+        PackedLong packedLong = new PackedLong(Integer.MAX_VALUE, Integer.MAX_VALUE);
+        long encodedLong = packedLong.encode();
+    }
+
+}


### PR DESCRIPTION
This is a port of https://github.com/oltpbenchmark/oltpbench/pull/320 which was written by @bglasber

The original PR description is copied below.

---

When generating an auctionmark database with a larger scale factor (e.g. 50), there are collisions in UserIds because there not enough bits allocated for OFFSET. There is some space left over in the CompositeId, so I've allocated a few more bits. Also, I've reordered the fields in UserId to match how they are packed in the compositeId. I've verified that this fix works to generate an auctionmark database with scalefactor 50.

The number of rows also exceeds the max values for short, so I've switched those to int in AuctionmarkLoader.

I propose changing the encode method on CompositeId to throw an IllegalArgumentException rather than assert. By default, asserts are not triggered, which means that we receive no warning that IDs may collide. This issue results in confusing errors that are difficult to track down for end-users. I've added code and a test to this effect.

All other tests pass with ant junit.