### PR TITLE
Update maven.yml with the right version name (2021-SNAPSHOT).

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ on:
     branches: [ main ]
 
 env:
-  POM_VERSION: 2021
+  POM_VERSION: 2021-SNAPSHOT
 
 jobs:
   build-and-upload:


### PR DESCRIPTION
Forgot to update the maven.yml with the SNAPSHOT version PR.