### PR TITLE
Fix TATPLoader for HSQLDB.

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/tatp/TATPLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tatp/TATPLoader.java
@@ -293,12 +293,13 @@ public class TATPLoader extends Loader<TATPBenchmark> {
                 }
                 int[] results = spe_pstmt.executeBatch();
 
-
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(String.format("%s: %d", TATPConstants.TABLENAME_CALL_FORWARDING, cal_total));
+                if (cal_added) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format("%s: %d", TATPConstants.TABLENAME_CALL_FORWARDING, cal_total));
+                    }
+                    results = cal_pstmt.executeBatch();
+                    cal_added = false;
                 }
-                results = cal_pstmt.executeBatch();
-
 
             }
         }


### PR DESCRIPTION
executeBatch should not be called unless addBatch was called.

---

These errors all manifest occasionally in the Java maven tests because those all use HSQLDB. Regular PostgreSQL and MySQL directly query the catalog and therefore are unaffected.