### PR TITLE
Strip out HikariCP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ A significant portion of the modernization was contributed by [Tim Veil @ Cockro
 * Removed various forms of dead code and stale configurations.
 * Removed calls to `commit()` during `Loader` operations.
 * Refactored `Worker` and `Loader` usage of `Connection` objects and cleaned up transaction handling.
-* Introduced `HikariCP` as connection pool and `DataSource` instead of building connections from `DriverManager` as needed (default `poolsize` is 12).
 * Introduced [Dependabot](https://dependabot.com/) to keep Maven dependencies up to date.
 * Simplified output flags by removing most of them, generally leaving the reporting functionality enabled by default.
 * Provided an alternate `Catalog` that can be populated directly from the configured Benchmark database. The old catalog was proxied through `HSQLDB` -- this remains an option for DBMSes that may have incomplete catalog support.

--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <version>5.0.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
             <version>2.7</version>

--- a/src/main/java/com/oltpbenchmark/DBWorkload.java
+++ b/src/main/java/com/oltpbenchmark/DBWorkload.java
@@ -122,7 +122,6 @@ public class DBWorkload {
             wrkld.setUsername(xmlConfig.getString("username"));
             wrkld.setPassword(xmlConfig.getString("password"));
             wrkld.setBatchSize(xmlConfig.getInt("batchsize", 128));
-            wrkld.setPoolSize(xmlConfig.getInt("poolsize", 12));
             wrkld.setMaxRetries(xmlConfig.getInt("retries", 3));
 
             int terminals = xmlConfig.getInt("terminals[not(@bench)]", 0);
@@ -164,7 +163,6 @@ public class DBWorkload {
             initDebug.put("Type", wrkld.getDatabaseType());
             initDebug.put("Driver", wrkld.getDriverClass());
             initDebug.put("URL", wrkld.getUrl());
-            initDebug.put("Pool Size", wrkld.getPoolSize());
             initDebug.put("Isolation", wrkld.getIsolationString());
             initDebug.put("Scale Factor", wrkld.getScaleFactor());
 

--- a/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
@@ -36,7 +36,6 @@ public class WorkloadConfiguration {
     private String username;
     private String password;
     private String driverClass;
-    private int poolSize;
     private int batchSize;
     private int maxRetries;
     private double scaleFactor = 1.0;
@@ -101,14 +100,6 @@ public class WorkloadConfiguration {
 
     public void setDriverClass(String driverClass) {
         this.driverClass = driverClass;
-    }
-
-    public int getPoolSize() {
-        return poolSize;
-    }
-
-    public void setPoolSize(int poolSize) {
-        this.poolSize = poolSize;
     }
 
     public int getBatchSize() {
@@ -293,7 +284,6 @@ public class WorkloadConfiguration {
                 ", username='" + username + '\'' +
                 ", password='" + password + '\'' +
                 ", driverClass='" + driverClass + '\'' +
-                ", poolSize=" + poolSize +
                 ", batchSize=" + batchSize +
                 ", maxRetries=" + maxRetries +
                 ", scaleFactor=" + scaleFactor +

--- a/src/main/java/com/oltpbenchmark/api/LoaderThread.java
+++ b/src/main/java/com/oltpbenchmark/api/LoaderThread.java
@@ -41,7 +41,7 @@ public abstract class LoaderThread implements Runnable {
     @Override
     public final void run() {
         beforeLoad();
-        try (Connection conn = benchmarkModule.getConnection()) {
+        try (Connection conn = benchmarkModule.makeConnection()) {
             load(conn);
         } catch (SQLException ex) {
             SQLException next_ex = ex.getNextException();

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -336,7 +336,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
         if (LOG.isDebugEnabled()) {
             LOG.debug("desired transaction isolation mode = {}", isolationMode);
         }
-        try (Connection conn = benchmarkModule.getConnection()) {
+        try (Connection conn = benchmarkModule.makeConnection()) {
 
 
             if (!conn.getAutoCommit()) {

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -48,6 +48,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
     private final int id;
     private final T benchmarkModule;
+    protected final Connection conn;
     protected final WorkloadConfiguration configuration;
     protected final TransactionTypes transactionTypes;
     protected final Map<TransactionType, Procedure> procedures = new HashMap<>();
@@ -70,6 +71,14 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
         this.state = this.configuration.getWorkloadState();
         this.currStatement = null;
         this.transactionTypes = this.configuration.getTransTypes();
+
+        try {
+            this.conn = this.benchmarkModule.makeConnection();
+            this.conn.setAutoCommit(false);
+            this.conn.setTransactionIsolation(this.configuration.getIsolationMode());
+        } catch (SQLException ex) {
+            throw new RuntimeException("Failed to connect to database", ex);
+        }
 
         // Generate all the Procedures that we're going to need
         this.procedures.putAll(this.benchmarkModule.getProcedures());
@@ -152,6 +161,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
     public final Histogram<TransactionType> getTransactionErrorHistogram() {
         return (this.txnErrors);
     }
+
     public final Histogram<TransactionType> getTransactionRetryDifferentHistogram() {
         return (this.txtRetryDifffernt);
     }
@@ -327,27 +337,11 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * @param pieceOfWork
      */
     protected final TransactionType doWork(SubmittedProcedure pieceOfWork) {
-
         final DatabaseType type = configuration.getDatabaseType();
         final TransactionType transactionType = transactionTypes.getType(pieceOfWork.getType());
 
-        final int isolationMode = this.configuration.getIsolationMode();
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("desired transaction isolation mode = {}", isolationMode);
-        }
-        try (Connection conn = benchmarkModule.makeConnection()) {
-
-
-            if (!conn.getAutoCommit()) {
-                LOG.warn("autocommit is already false at beginning of work.  this is a problem");
-            }
-
-            conn.setAutoCommit(false);
-            conn.setTransactionIsolation(isolationMode);
-
+        try {
             int retryCount = 0;
-
             int maxRetryCount = configuration.getMaxRetries();
 
             while (retryCount < maxRetryCount && this.state.getGlobalState() != State.DONE) {
@@ -425,13 +419,6 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                 }
 
             }
-
-            if (conn.getAutoCommit()) {
-                LOG.warn("autocommit is already true at end of work.  this is a problem");
-            }
-
-            conn.setAutoCommit(true);
-
         } catch (SQLException ex) {
             String msg = String.format("Unexpected SQLException in '%s' when executing '%s' on [%s]", this, transactionType, type.name());
 
@@ -499,7 +486,12 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * @param error TODO
      */
     public void tearDown(boolean error) {
-
+        try {
+            conn.close();
+        } catch (SQLException e) {
+            LOG.warn("Connection couldn't be closed. Error:");
+            e.printStackTrace();
+        }
     }
 
     public void initializeState() {

--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkProfile.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkProfile.java
@@ -342,7 +342,7 @@ public class AuctionMarkProfile {
 
                 // Otherwise we have to go fetch everything again
                 // So first we want to reset the database
-                try (Connection conn = benchmark.getConnection()) {
+                try (Connection conn = benchmark.makeConnection()) {
 
                     if (AuctionMarkConstants.RESET_DATABASE_ENABLE) {
                         if (LOG.isDebugEnabled()) {
@@ -360,7 +360,7 @@ public class AuctionMarkProfile {
                 }
 
                 Config results;
-                try (Connection conn = benchmark.getConnection()) {
+                try (Connection conn = benchmark.makeConnection()) {
                     results = worker.getProcedure(LoadConfig.class).run(conn);
                 }
 

--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkWorker.java
@@ -88,7 +88,7 @@ public class AuctionMarkWorker extends Worker<AuctionMarkBenchmark> {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug(String.format("Executing %s in separate thread", txnType));
                     }
-                    try (Connection conn = getBenchmarkModule().getConnection()) {
+                    try (Connection conn = getBenchmarkModule().makeConnection()) {
                         executeCloseAuctions(conn, (CloseAuctions) proc);
                     } catch (Exception ex) {
                         throw new RuntimeException(ex);

--- a/src/main/java/com/oltpbenchmark/benchmarks/epinions/EpinionsBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/epinions/EpinionsBenchmark.java
@@ -67,7 +67,7 @@ public class EpinionsBenchmark extends BenchmarkModule {
             ArrayList<String> item_ids = new ArrayList<>();
             String userCount = SQLUtil.selectColValues(databaseType, t, "u_id");
 
-            try (Connection metaConn = this.getConnection()) {
+            try (Connection metaConn = this.makeConnection()) {
                 try (Statement stmt = metaConn.createStatement()) {
                     try (ResultSet res = stmt.executeQuery(userCount)) {
                         while (res.next()) {

--- a/src/main/java/com/oltpbenchmark/benchmarks/hyadapt/HYADAPTBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/hyadapt/HYADAPTBenchmark.java
@@ -53,7 +53,7 @@ public class HYADAPTBenchmark extends BenchmarkModule {
 
         String userCount = SQLUtil.getCountSQL(this.workConf.getDatabaseType(), t);
         int init_record_count = 0;
-        try (Connection metaConn = this.getConnection()) {
+        try (Connection metaConn = this.makeConnection()) {
 
             try (Statement stmt = metaConn.createStatement()) {
                 try (ResultSet res = stmt.executeQuery(userCount)) {
@@ -65,7 +65,7 @@ public class HYADAPTBenchmark extends BenchmarkModule {
             }
             //
             for (int i = 0; i < workConf.getTerminals(); ++i) {
-//                Connection conn = this.getConnection();
+//                Connection conn = this.makeConnection();
 //                conn.setAutoCommit(false);
                 workers.add(new HYADAPTWorker(this, i, init_record_count + 1));
             }

--- a/src/main/java/com/oltpbenchmark/benchmarks/seats/SEATSProfile.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/seats/SEATSProfile.java
@@ -294,7 +294,7 @@ public class SEATSProfile {
             LoadConfig proc = worker.getProcedure(LoadConfig.class);
 
             Config results;
-            try (Connection conn = benchmark.getConnection()) {
+            try (Connection conn = benchmark.makeConnection()) {
                 results = proc.run(conn);
             }
             // CONFIG_PROFILE

--- a/src/main/java/com/oltpbenchmark/benchmarks/seats/SEATSWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/seats/SEATSWorker.java
@@ -268,7 +268,7 @@ public class SEATSWorker extends Worker<SEATSBenchmark> {
 
         // Fire off a FindOpenSeats so that we can prime ourselves
         FindOpenSeats proc = this.getProcedure(FindOpenSeats.class);
-        try (Connection conn = getBenchmarkModule().getConnection()) {
+        try (Connection conn = getBenchmarkModule().makeConnection()) {
             boolean ret = this.executeFindOpenSeats(conn, proc);
         } catch (SQLException ex) {
             throw new RuntimeException(ex);

--- a/src/main/java/com/oltpbenchmark/benchmarks/sibench/SIBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/sibench/SIBenchmark.java
@@ -50,7 +50,7 @@ public class SIBenchmark extends BenchmarkModule {
 
         String recordCount = SQLUtil.getMaxColSQL(this.workConf.getDatabaseType(), t, "id");
 
-        try (Connection metaConn = this.getConnection();
+        try (Connection metaConn = this.makeConnection();
              Statement stmt = metaConn.createStatement();
              ResultSet res = stmt.executeQuery(recordCount)) {
 

--- a/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
@@ -55,7 +55,7 @@ public class YCSBBenchmark extends BenchmarkModule {
 
             String userCount = SQLUtil.getMaxColSQL(this.workConf.getDatabaseType(), t, "ycsb_key");
 
-            try (Connection metaConn = this.getConnection();
+            try (Connection metaConn = this.makeConnection();
                  Statement stmt = metaConn.createStatement();
                  ResultSet res = stmt.executeQuery(userCount)) {
                 int init_record_count = 0;

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -16,8 +16,6 @@ log4j.logger.com.oltpbenchmark.api.Loader=INFO
 log4j.logger.com.oltpbenchmark.api.Procedure=INFO
 log4j.logger.com.oltpbenchmark.catalog.Catalog=INFO
 log4j.logger.com.oltpbenchmark.util.ThreadUtil=INFO
-log4j.logger.com.zaxxer.hikari.HikariConfig=INFO
-log4j.logger.com.zaxxer.hikari.pool.HikariPool=WARN
 
 ## to see UserAbortException messages set this logger to DEBUG
 log4j.logger.com.oltpbenchmark.api.ABORT_LOG=WARN

--- a/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
@@ -86,8 +86,6 @@ public abstract class AbstractTestCase<T extends BenchmarkModule> extends TestCa
         this.workConf.setDatabaseType(DB_TYPE);
         this.workConf.setUrl(DB_CONNECTION + this.dbName);
         this.workConf.setScaleFactor(DB_SCALE_FACTOR);
-        // TODO(WAN): 12 is arbitrary.
-        this.workConf.setPoolSize(12);
 
         this.benchmark = ClassUtil.newInstance(clazz,
                 new Object[]{this.workConf},
@@ -98,7 +96,7 @@ public abstract class AbstractTestCase<T extends BenchmarkModule> extends TestCa
         this.benchmark.refreshCatalog();
         this.catalog = this.benchmark.getCatalog();
         assertNotNull(this.catalog);
-        this.conn = this.benchmark.getConnection();
+        this.conn = this.benchmark.makeConnection();
         assertNotNull(this.conn);
         assertFalse(this.conn.isReadOnly());
     }


### PR DESCRIPTION
We observed performance degradation in NoisePage (20k to 10k TPC-C, 7k to 5k TATP) when using HikariCP compared to the old "one worker maintains one persistent connection" model.

HikariCP may also muddy numbers slightly. Consider for example running TATP with 400 terminals and 12 pool size. How many clients are being served, 400 or 12?

Additionally, HikariCP introduces some performance overhead with the pool monitoring and leak detection checks. Since we're just running benchmarks with a fixed number of terminals / workers, we don't _need_ a pool (though a pool may be nice to support dynamic resizing in the future).

Given the above considerations, we propose stripping out HikariCP.