### PR TITLE
Revert to the old logic for post-phase checks.

### DIFF
--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -198,7 +198,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
         // wait for start
         state.blockForStart();
         State preState, postState;
-        Phase phase;
+        Phase phase, postPhase;
 
         TransactionType invalidTT = TransactionType.INVALID;
 
@@ -294,6 +294,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
             long end = System.nanoTime();
             postState = state.getGlobalState();
+            postPhase = state.getCurrentPhase();
 
             switch (postState) {
                 case MEASURE:
@@ -302,7 +303,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                     // changed, otherwise we're recording results for a query
                     // that either started during the warmup phase or ended
                     // after the timer went off.
-                    if (preState == State.MEASURE && type != null && this.state.getCurrentPhase() != null && this.state.getCurrentPhase().getId() == phase.getId()) {
+                    if (preState == State.MEASURE && type != null && phase != null && postPhase != null && postPhase.getId() == phase.getId()) {
                         latencies.addLatency(type.getId(), start, end, this.id, phase.getId());
                         intervalRequests.incrementAndGet();
                     }


### PR DESCRIPTION
The refactor exposed a race condition that was likely to be
hit when you had a high number of terminals, manifesting as a null
pointer exception on trying to get the phase from the state.
It isn't immediately clear where this race condition is, so we
are reverting to the old "get the state once" logic for now.

To be clear, this PR does not fix the bug, which has been around for a while.
This PR will just reduce the probability that the bug trips.