### PR TITLE
fix broken docker examples that reference old database name

### DIFF
--- a/docker/cockroach-latest/docker-compose.yml
+++ b/docker/cockroach-latest/docker-compose.yml
@@ -46,6 +46,6 @@ services:
     environment:
       - COCKROACH_HOST=lb:26257
       - COCKROACH_INSECURE=true
-      - DATABASE_NAME=oltpbench
+      - DATABASE_NAME=benchbase
     depends_on:
       - lb

--- a/docker/mysql-5/docker-compose.yml
+++ b/docker/mysql-5/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_ROOT_HOST: "%"
-      MYSQL_DATABASE: oltpbench
+      MYSQL_DATABASE: benchbase
     ports:
       - "3306:3306"
 

--- a/docker/mysql-latest/docker-compose.yml
+++ b/docker/mysql-latest/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_ROOT_HOST: "%"
-      MYSQL_DATABASE: oltpbench
+      MYSQL_DATABASE: benchbase
     ports:
       - "3306:3306"
 

--- a/docker/postgres-latest/docker-compose.yml
+++ b/docker/postgres-latest/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: password
-      POSTGRES_DB: oltpbench
+      POSTGRES_DB: benchbase
     ports:
       - "5432:5432"
 


### PR DESCRIPTION
updating docker files with correct database name (`benchbase` instead of `oltpbench`)