### PR TITLE
Add dialect-spanner.xml for YCSB

### DIFF
--- a/src/main/resources/benchmarks/ycsb/dialect-spanner.xml
+++ b/src/main/resources/benchmarks/ycsb/dialect-spanner.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<dialects>
+    <dialect type="SPANNER">
+        <procedure name="ReadModifyWriteRecord">
+            <statement name="selectStmt">
+                SELECT * FROM usertable WHERE ycsb_key=?
+            </statement>
+        </procedure>
+        <procedure name="InsertRecord">
+            <statement name="insertStmt">
+                INSERT INTO usertable (ycsb_key, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+            </statement>
+        </procedure>
+    </dialect>
+</dialects>


### PR DESCRIPTION
I fixed SQL syntax errors in YCSB on Spanner by adding `dialect-spanner.xml`.

Syntax error on `SELECT FOR UPDATE`:

```
[DEBUG] 2021-12-17 15:56:19,079 [YCSBWorker<000>]  com.oltpbenchmark.api.Worker doWork - Retryable SQLException occurred during [com.oltpbenchmark.benchmarks.ycsb.procedures.ReadModifyWriteRecord/06]... current retry attempt [0], max retry attempts [3], sql state [null], error code [3].
com.google.cloud.spanner.jdbc.JdbcSqlExceptionFactory$JdbcSqlExceptionImpl: INVALID_ARGUMENT: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Syntax error: Expected end of input but got keyword FOR [at 1:44]
SELECT * FROM usertable where YCSB_KEY=@p1 FOR UPDATE
                                           ^ - Statement: 'SELECT * FROM usertable where YCSB_KEY=@p1 FOR UPDATE'
	at com.google.cloud.spanner.jdbc.JdbcSqlExceptionFactory.of(JdbcSqlExceptionFactory.java:222)
	at com.google.cloud.spanner.jdbc.AbstractJdbcStatement.executeQuery(AbstractJdbcStatement.java:194)
	at com.google.cloud.spanner.jdbc.AbstractJdbcStatement.executeQuery(AbstractJdbcStatement.java:175)
	at com.google.cloud.spanner.jdbc.JdbcPreparedStatement.executeQuery(JdbcPreparedStatement.java:65)
	at com.oltpbenchmark.benchmarks.ycsb.procedures.ReadModifyWriteRecord.run(ReadModifyWriteRecord.java:46)
	at com.oltpbenchmark.benchmarks.ycsb.YCSBWorker.readModifyWriteRecord(YCSBWorker.java:125)
	at com.oltpbenchmark.benchmarks.ycsb.YCSBWorker.executeWork(YCSBWorker.java:90)
	at com.oltpbenchmark.api.Worker.doWork(Worker.java:358)
	at com.oltpbenchmark.api.Worker.run(Worker.java:269)
	at java.base/java.lang.Thread.run(Thread.java:833)
...
```

Syntax error on `INSERT INTO`:

```
[DEBUG] 2021-12-17 15:56:15,449 [YCSBWorker<000>]  com.oltpbenchmark.api.Worker doWork - Retryable SQLException occurred during [com.oltpbenchmark.benchmarks.ycsb.procedures.InsertRecord/02]... current retry attempt [0], max retry attempts [3], sql state [null], error code [3].
com.google.cloud.spanner.jdbc.JdbcSqlExceptionFactory$JdbcSqlExceptionImpl: INVALID_ARGUMENT: com.google.api.gax.rpc.InvalidArgumentException: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: INSERT must specify a column list [at 1:1]
INSERT INTO usertable VALUES (@p1,@p2,@p3,@p4,@p5,@p6,@p7,@p8,@p9,@p10,@p11)
^
	at com.google.cloud.spanner.jdbc.JdbcSqlExceptionFactory.of(JdbcSqlExceptionFactory.java:222)
	at com.google.cloud.spanner.jdbc.AbstractJdbcStatement.executeLargeUpdate(AbstractJdbcStatement.java:231)
	at com.google.cloud.spanner.jdbc.AbstractJdbcStatement.executeUpdate(AbstractJdbcStatement.java:210)
	at com.google.cloud.spanner.jdbc.JdbcPreparedStatement.executeUpdate(JdbcPreparedStatement.java:76)
	at com.oltpbenchmark.benchmarks.ycsb.procedures.InsertRecord.run(InsertRecord.java:41)
	at com.oltpbenchmark.benchmarks.ycsb.YCSBWorker.insertRecord(YCSBWorker.java:132)
	at com.oltpbenchmark.benchmarks.ycsb.YCSBWorker.executeWork(YCSBWorker.java:88)
	at com.oltpbenchmark.api.Worker.doWork(Worker.java:358)
	at com.oltpbenchmark.api.Worker.run(Worker.java:269)
	at java.base/java.lang.Thread.run(Thread.java:833)
...
```