### PR TITLE
Comment out keying and wait times for default TPC-C configs.

### DIFF
--- a/config/cockroachdb/sample_tpcc_config.xml
+++ b/config/cockroachdb/sample_tpcc_config.xml
@@ -27,28 +27,28 @@
     <transactiontypes>
         <transactiontype>
             <name>NewOrder</name>
-            <preExecutionWait>18000</preExecutionWait>
-            <postExecutionWait>12000</postExecutionWait>
+            <!--<preExecutionWait>18000</preExecutionWait>-->
+            <!--<postExecutionWait>12000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>Payment</name>
-            <preExecutionWait>3000</preExecutionWait>
-            <postExecutionWait>12000</postExecutionWait>
+            <!--<preExecutionWait>3000</preExecutionWait>-->
+            <!--<postExecutionWait>12000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>OrderStatus</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>10000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>10000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>Delivery</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>5000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>5000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>StockLevel</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>5000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>5000</postExecutionWait>-->
         </transactiontype>
     </transactiontypes>
 </parameters>

--- a/config/mysql/sample_tpcc_config.xml
+++ b/config/mysql/sample_tpcc_config.xml
@@ -27,28 +27,28 @@
     <transactiontypes>
         <transactiontype>
             <name>NewOrder</name>
-            <preExecutionWait>18000</preExecutionWait>
-            <postExecutionWait>12000</postExecutionWait>
+            <!--<preExecutionWait>18000</preExecutionWait>-->
+            <!--<postExecutionWait>12000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>Payment</name>
-            <preExecutionWait>3000</preExecutionWait>
-            <postExecutionWait>12000</postExecutionWait>
+            <!--<preExecutionWait>3000</preExecutionWait>-->
+            <!--<postExecutionWait>12000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>OrderStatus</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>10000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>10000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>Delivery</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>5000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>5000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>StockLevel</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>5000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>5000</postExecutionWait>-->
         </transactiontype>
     </transactiontypes>
 </parameters>

--- a/config/noisepage/sample_tpcc_config.xml
+++ b/config/noisepage/sample_tpcc_config.xml
@@ -27,28 +27,28 @@
     <transactiontypes>
         <transactiontype>
             <name>NewOrder</name>
-            <preExecutionWait>18000</preExecutionWait>
-            <postExecutionWait>12000</postExecutionWait>
+            <!--<preExecutionWait>18000</preExecutionWait>-->
+            <!--<postExecutionWait>12000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>Payment</name>
-            <preExecutionWait>3000</preExecutionWait>
-            <postExecutionWait>12000</postExecutionWait>
+            <!--<preExecutionWait>3000</preExecutionWait>-->
+            <!--<postExecutionWait>12000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>OrderStatus</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>10000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>10000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>Delivery</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>5000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>5000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>StockLevel</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>5000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>5000</postExecutionWait>-->
         </transactiontype>
     </transactiontypes>
 </parameters>

--- a/config/postgres/sample_tpcc_config.xml
+++ b/config/postgres/sample_tpcc_config.xml
@@ -27,28 +27,28 @@
     <transactiontypes>
         <transactiontype>
             <name>NewOrder</name>
-            <preExecutionWait>18000</preExecutionWait>
-            <postExecutionWait>12000</postExecutionWait>
+            <!--<preExecutionWait>18000</preExecutionWait>-->
+            <!--<postExecutionWait>12000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>Payment</name>
-            <preExecutionWait>3000</preExecutionWait>
-            <postExecutionWait>12000</postExecutionWait>
+            <!--<preExecutionWait>3000</preExecutionWait>-->
+            <!--<postExecutionWait>12000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>OrderStatus</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>10000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>10000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>Delivery</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>5000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>5000</postExecutionWait>-->
         </transactiontype>
         <transactiontype>
             <name>StockLevel</name>
-            <preExecutionWait>2000</preExecutionWait>
-            <postExecutionWait>5000</postExecutionWait>
+            <!--<preExecutionWait>2000</preExecutionWait>-->
+            <!--<postExecutionWait>5000</postExecutionWait>-->
         </transactiontype>
     </transactiontypes>
 </parameters>


### PR DESCRIPTION
Comment out keying and wait times for default TPC-C configs.

The keying and wait times are required by the spec;
they should be enabled for a spec-compliant run.

However, most people probably do not want this enabled by default.
For example, if you're developing a system and trying to push
as many TPC-C transactions through it as you can.

---

This PR is mostly for the benefit of people who haven't been following along (e.g., me)
and who get surprised that TPC-C numbers seem to have plummeted after #83.