### PR TITLE
Results formatting: explicitly mark throughput as throughput; introduce goodput.

### DIFF
--- a/src/main/java/com/oltpbenchmark/Results.java
+++ b/src/main/java/com/oltpbenchmark/Results.java
@@ -86,8 +86,12 @@ public final class Results {
         return abortMessages;
     }
 
-    public double requestsPerSecond() {
+    public double requestsPerSecondThroughput() {
         return (double) measuredRequests / (double) nanoseconds * 1e9;
+    }
+
+    public double requestsPerSecondGoodput() {
+        return (double) success.getSampleCount() / (double) nanoseconds * 1e9;
     }
 
     public List<Sample> getLatencySamples() {
@@ -104,9 +108,19 @@ public final class Results {
 
     @Override
     public String toString() {
-        return "Results(nanoSeconds=" + nanoseconds + ", measuredRequests=" + measuredRequests + ") = " + requestsPerSecond() + " requests/sec";
+        StringBuilder sb = new StringBuilder();
+        sb.append("Results(nanoSeconds=");
+        sb.append(nanoseconds);
+        sb.append(", measuredRequests=");
+        sb.append(measuredRequests);
+        sb.append(") = ");
+        sb.append(requestsPerSecondThroughput());
+        sb.append(" requests/sec (throughput)");
+        sb.append(", ");
+        sb.append(requestsPerSecondGoodput());
+        sb.append(" requests/sec (goodput)");
+        return sb.toString();
     }
-
 
 
 }

--- a/src/main/java/com/oltpbenchmark/util/ResultWriter.java
+++ b/src/main/java/com/oltpbenchmark/util/ResultWriter.java
@@ -107,7 +107,8 @@ public class ResultWriter {
         summaryMap.put("DBMS Version", collector.collectVersion());
         summaryMap.put("Benchmark Type", benchType);
         summaryMap.put("Latency Distribution", results.getDistributionStatistics().toMap());
-        summaryMap.put("Throughput (requests/second)", results.requestsPerSecond());
+        summaryMap.put("Throughput (requests/second)", results.requestsPerSecondThroughput());
+        summaryMap.put("Goodput (requests/second)", results.requestsPerSecondGoodput());
         for (String field : BENCHMARK_KEY_FIELD) {
             summaryMap.put(field, expConf.getString(field));
         }


### PR DESCRIPTION
Explicitly mark throughput as throughput; introduce goodput.

This clarifies that the former requests/second number reported is a true
measure of the requests per second, i.e., it includes rejected and aborted
transactions.

Specifically, the former results string
```
Results(nanoSeconds=XXX, measuredRequests=XXX) = XXX.XXX requests/sec
```
is now of the form
```
Results(nanoSeconds=XXX, measuredRequests=XXX) = XXX.XXX requests/sec (throughput), XXX.XXX requests/sec (goodput)
```
where goodput is reported as the number of completed transactions.

We also write an additional Goodput line to the summary file generated.