### PR TITLE
Change so Wikipedia benchmark will work with CockroachDB's SQL statement size limit

### DIFF
--- a/config/cockroachdb/sample_wikipedia_config.xml
+++ b/config/cockroachdb/sample_wikipedia_config.xml
@@ -8,10 +8,13 @@
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>
-    <batchsize>128</batchsize>
+    <batchsize>4</batchsize>
 
     <!-- Scale factor is the number of wikipages *1000 -->
     <scalefactor>1</scalefactor>
+
+    <!-- Limit on the size of the string inserted into the OLD_TEXT column -->
+    <oldtextmaxlen>1048576</oldtextmaxlen>
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/cockroachdb/sample_wikipedia_config.xml
+++ b/config/cockroachdb/sample_wikipedia_config.xml
@@ -8,10 +8,13 @@
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>
-    <batchsize>128</batchsize>
+    <batchsize>8</batchsize>
 
     <!-- Scale factor is the number of wikipages *1000 -->
     <scalefactor>1</scalefactor>
+
+    <!-- Limit on the size of the string inserted into the OLD_TEXT column -->
+    <oldtextmaxlen>1048576</oldtextmaxlen>
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/cockroachdb/sample_wikipedia_config.xml
+++ b/config/cockroachdb/sample_wikipedia_config.xml
@@ -8,13 +8,10 @@
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>
-    <batchsize>8</batchsize>
+    <batchsize>128</batchsize>
 
     <!-- Scale factor is the number of wikipages *1000 -->
     <scalefactor>1</scalefactor>
-
-    <!-- Limit on the size of the string inserted into the OLD_TEXT column -->
-    <oldtextmaxlen>1048576</oldtextmaxlen>
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/src/main/java/com/oltpbenchmark/DBWorkload.java
+++ b/src/main/java/com/oltpbenchmark/DBWorkload.java
@@ -138,6 +138,7 @@ public class DBWorkload {
             wrkld.setIsolationMode(xmlConfig.getString("isolation" + pluginTest, isolationMode));
             wrkld.setScaleFactor(xmlConfig.getDouble("scalefactor", 1.0));
             wrkld.setDataDir(xmlConfig.getString("datadir", "."));
+            wrkld.setOldTextMaxLen(xmlConfig.getInt("oldtextmaxlen", Integer.MAX_VALUE));
 
             double selectivity = -1;
             try {

--- a/src/main/java/com/oltpbenchmark/DBWorkload.java
+++ b/src/main/java/com/oltpbenchmark/DBWorkload.java
@@ -138,7 +138,6 @@ public class DBWorkload {
             wrkld.setIsolationMode(xmlConfig.getString("isolation" + pluginTest, isolationMode));
             wrkld.setScaleFactor(xmlConfig.getDouble("scalefactor", 1.0));
             wrkld.setDataDir(xmlConfig.getString("datadir", "."));
-            wrkld.setOldTextMaxLen(xmlConfig.getInt("oldtextmaxlen", Integer.MAX_VALUE));
 
             double selectivity = -1;
             try {

--- a/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
@@ -47,7 +47,6 @@ public class WorkloadConfiguration {
     private TransactionTypes transTypes = null;
     private int isolationMode = Connection.TRANSACTION_SERIALIZABLE;
     private String dataDir = null;
-    private int oldTextMaxLen = Integer.MAX_VALUE;
 
     public String getBenchmarkName() {
         return benchmarkName;
@@ -216,14 +215,6 @@ public class WorkloadConfiguration {
 
     public void setTerminals(int terminals) {
         this.terminals = terminals;
-    }
-
-    public int getOldTextMaxLen() {
-        return oldTextMaxLen;
-    }
-
-    public void setOldTextMaxLen(int m) {
-        this.oldTextMaxLen = m;
     }
 
     public TransactionTypes getTransTypes() {

--- a/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
@@ -47,6 +47,7 @@ public class WorkloadConfiguration {
     private TransactionTypes transTypes = null;
     private int isolationMode = Connection.TRANSACTION_SERIALIZABLE;
     private String dataDir = null;
+    private int oldTextMaxLen = Integer.MAX_VALUE;
 
     public String getBenchmarkName() {
         return benchmarkName;
@@ -215,6 +216,14 @@ public class WorkloadConfiguration {
 
     public void setTerminals(int terminals) {
         this.terminals = terminals;
+    }
+
+    public int getOldTextMaxLen() {
+        return oldTextMaxLen;
+    }
+
+    public void setOldTextMaxLen(int m) {
+        this.oldTextMaxLen = m;
     }
 
     public TransactionTypes getTransTypes() {

--- a/src/main/java/com/oltpbenchmark/benchmarks/wikipedia/WikipediaLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/wikipedia/WikipediaLoader.java
@@ -489,6 +489,7 @@ public class WikipediaLoader extends Loader<WikipediaBenchmark> {
 
         Random rand = new Random();
 
+
         WikipediaBenchmark b = this.benchmark;
         int batchSize = 1;
         Zipf h_users = new Zipf(rand, 1, this.num_users, WikipediaConstants.REVISION_USER_SIGMA);
@@ -497,7 +498,6 @@ public class WikipediaLoader extends Loader<WikipediaBenchmark> {
         FlatHistogram<Integer> h_minorEdit = b.minorEdit;
         FlatHistogram<Integer> h_nameLength = new FlatHistogram<>(rand, UserHistograms.NAME_LENGTH);
         FlatHistogram<Integer> h_numRevisions = new FlatHistogram<>(rand, PageHistograms.REVISIONS_PER_PAGE);
-        final int oldTextMaxLen = b.getWorkloadConfiguration().getOldTextMaxLen();
 
         final int rev_comment_max = revTable.getColumnByName("rev_comment").getSize();
         int rev_id = 1;
@@ -541,8 +541,7 @@ public class WikipediaLoader extends Loader<WikipediaBenchmark> {
                     // Insert the text
                     int col = 1;
                     textInsert.setInt(col++, rev_id); // old_id
-                    int maxLen = old_text.length > oldTextMaxLen ? oldTextMaxLen : old_text.length;
-                    textInsert.setString(col++, new String(old_text, 0, maxLen)); // old_text
+                    textInsert.setString(col++, new String(old_text)); // old_text
                     textInsert.setString(col++, "utf-8"); // old_flags
                     textInsert.setInt(col++, page_id); // old_page
                     textInsert.addBatch();

--- a/src/main/java/com/oltpbenchmark/benchmarks/wikipedia/WikipediaLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/wikipedia/WikipediaLoader.java
@@ -489,7 +489,6 @@ public class WikipediaLoader extends Loader<WikipediaBenchmark> {
 
         Random rand = new Random();
 
-
         WikipediaBenchmark b = this.benchmark;
         int batchSize = 1;
         Zipf h_users = new Zipf(rand, 1, this.num_users, WikipediaConstants.REVISION_USER_SIGMA);
@@ -498,6 +497,7 @@ public class WikipediaLoader extends Loader<WikipediaBenchmark> {
         FlatHistogram<Integer> h_minorEdit = b.minorEdit;
         FlatHistogram<Integer> h_nameLength = new FlatHistogram<>(rand, UserHistograms.NAME_LENGTH);
         FlatHistogram<Integer> h_numRevisions = new FlatHistogram<>(rand, PageHistograms.REVISIONS_PER_PAGE);
+        final int oldTextMaxLen = b.getWorkloadConfiguration().getOldTextMaxLen();
 
         final int rev_comment_max = revTable.getColumnByName("rev_comment").getSize();
         int rev_id = 1;
@@ -541,7 +541,8 @@ public class WikipediaLoader extends Loader<WikipediaBenchmark> {
                     // Insert the text
                     int col = 1;
                     textInsert.setInt(col++, rev_id); // old_id
-                    textInsert.setString(col++, new String(old_text)); // old_text
+                    int maxLen = old_text.length > oldTextMaxLen ? oldTextMaxLen : old_text.length;
+                    textInsert.setString(col++, new String(old_text, 0, maxLen)); // old_text
                     textInsert.setString(col++, "utf-8"); // old_flags
                     textInsert.setInt(col++, page_id); // old_page
                     textInsert.addBatch();

--- a/src/main/resources/benchmarks/seats/ddl-cockroachdb.sql
+++ b/src/main/resources/benchmarks/seats/ddl-cockroachdb.sql
@@ -257,7 +257,7 @@ CREATE TABLE flight (
     FOREIGN KEY (f_depart_ap_id) REFERENCES airport (ap_id),
     FOREIGN KEY (f_arrive_ap_id) REFERENCES airport (ap_id)
 );
-CREATE INDEX f_depart_time_idx ON flight (f_depart_time);
+CREATE INDEX f_compound_idx ON flight (f_depart_time, f_al_id, f_depart_ap_id, f_arrive_ap_id);
 
 --
 -- RESERVATION

--- a/src/main/resources/benchmarks/seats/dialect-cockroachdb.xml
+++ b/src/main/resources/benchmarks/seats/dialect-cockroachdb.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<dialects>
+    <dialect type="POSTGRES">
+        <procedure name="DeleteReservation">
+            <statement name="UpdateCustomer">UPDATE customer SET C_BALANCE = C_BALANCE + ?, C_IATTR00 = ?, C_IATTR10 = C_IATTR10 - 1, C_IATTR11 = C_IATTR10 - 1 WHERE C_ID = ?</statement>
+            <statement name="GetCustomerByIdStr">SELECT C_ID FROM customer WHERE C_ID_STR = ?</statement>
+            <statement name="GetCustomerReservation">SELECT C_SATTR00, C_SATTR02, C_SATTR04, C_IATTR00, C_IATTR02, C_IATTR04, C_IATTR06, F_SEATS_LEFT, R_ID, R_SEAT, R_PRICE, R_IATTR00 FROM customer, flight, reservation WHERE C_ID = ? AND C_ID = R_C_ID AND F_ID = ? AND F_ID = R_F_ID</statement>
+            <statement name="UpdateFrequentFlyer">UPDATE frequent_flyer SET FF_IATTR10 = FF_IATTR10 - 1 WHERE FF_C_ID = ? AND FF_AL_ID = ?</statement>
+            <statement name="DeleteReservation">DELETE FROM reservation WHERE R_ID = ? AND R_C_ID = ? AND R_F_ID = ?</statement>
+            <statement name="UpdateFlight">UPDATE flight SET F_SEATS_LEFT = F_SEATS_LEFT + 1  WHERE F_ID = ?</statement>
+            <statement name="GetCustomerByFFNumber">SELECT C_ID, FF_AL_ID FROM customer, frequent_flyer WHERE FF_C_ID_STR = ? AND FF_C_ID = C_ID</statement>
+        </procedure>
+        <procedure name="FindFlights">
+            <statement name="GetFlights1">SELECT F_ID, F_AL_ID, F_SEATS_LEFT, F_DEPART_AP_ID, F_DEPART_TIME, F_ARRIVE_AP_ID, F_ARRIVE_TIME, AL_NAME, AL_IATTR00, AL_IATTR01 FROM flight, airline WHERE F_DEPART_AP_ID = ? AND F_DEPART_TIME &gt;= ? AND F_DEPART_TIME &lt;= ? AND F_AL_ID = AL_ID AND F_ARRIVE_AP_ID IN (??)</statement>
+            <statement name="GetFlights2">SELECT F_ID, F_AL_ID, F_SEATS_LEFT, F_DEPART_AP_ID, F_DEPART_TIME, F_ARRIVE_AP_ID, F_ARRIVE_TIME, AL_NAME, AL_IATTR00, AL_IATTR01 FROM flight, airline WHERE F_DEPART_AP_ID = ? AND F_DEPART_TIME &gt;= ? AND F_DEPART_TIME &lt;= ? AND F_AL_ID = AL_ID AND F_ARRIVE_AP_ID IN (??)</statement>
+            <statement name="GetFlights3">SELECT F_ID, F_AL_ID, F_SEATS_LEFT, F_DEPART_AP_ID, F_DEPART_TIME, F_ARRIVE_AP_ID, F_ARRIVE_TIME, AL_NAME, AL_IATTR00, AL_IATTR01 FROM flight, airline WHERE F_DEPART_AP_ID = ? AND F_DEPART_TIME &gt;= ? AND F_DEPART_TIME &lt;= ? AND F_AL_ID = AL_ID AND F_ARRIVE_AP_ID IN (??)</statement>
+            <statement name="GetAirportInfo">SELECT AP_CODE, AP_NAME, AP_CITY, AP_LONGITUDE, AP_LATITUDE, CO_ID, CO_NAME, CO_CODE_2, CO_CODE_3 FROM airport, country WHERE AP_ID = ? AND AP_CO_ID = CO_ID</statement>
+            <statement name="GetNearbyAirports">SELECT * FROM airport_distance WHERE D_AP_ID0 = ? AND D_DISTANCE &lt;= ? ORDER BY D_DISTANCE ASC </statement>
+        </procedure>
+        <procedure name="FindOpenSeats">
+            <statement name="GetFlight">SELECT F_STATUS, F_BASE_PRICE, F_SEATS_TOTAL, F_SEATS_LEFT, (F_BASE_PRICE + (F_BASE_PRICE * (1 - (F_SEATS_LEFT / F_SEATS_TOTAL)))) AS F_PRICE FROM flight WHERE F_ID = ?</statement>
+            <statement name="GetSeats">SELECT R_ID, R_F_ID, R_SEAT FROM reservation WHERE R_F_ID = ?</statement>
+        </procedure>
+        <procedure name="LoadConfig">
+            <statement name="getConfigProfile">SELECT * FROM config_profile</statement>
+            <statement name="getFlights">SELECT f_id FROM flight ORDER BY F_DEPART_TIME DESC LIMIT 10000</statement>
+            <statement name="getAirlineCodes">SELECT AL_ID, AL_IATA_CODE FROM airline WHERE AL_IATA_CODE != ''</statement>
+            <statement name="getAirportCodes">SELECT AP_ID, AP_CODE FROM airport</statement>
+            <statement name="getConfigHistogram">SELECT * FROM config_histograms</statement>
+            <statement name="getCountryCodes">SELECT CO_ID, CO_CODE_3 FROM country</statement>
+        </procedure>
+        <procedure name="NewReservation">
+            <statement name="InsertReservation">INSERT INTO reservation (R_ID, R_C_ID, R_F_ID, R_SEAT, R_PRICE, R_IATTR00, R_IATTR01, R_IATTR02, R_IATTR03, R_IATTR04, R_IATTR05, R_IATTR06, R_IATTR07, R_IATTR08) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)</statement>
+            <statement name="UpdateCustomer">UPDATE customer SET C_IATTR10 = C_IATTR10 + 1, C_IATTR11 = C_IATTR11 + 1, C_IATTR12 = ?, C_IATTR13 = ?, C_IATTR14 = ?, C_IATTR15 = ? WHERE C_ID = ?</statement>
+            <statement name="CheckCustomer">SELECT R_ID FROM reservation WHERE R_F_ID = ? AND R_C_ID = ?</statement>
+            <statement name="GetFlight">SELECT F_AL_ID, F_SEATS_LEFT, airline.* FROM flight, airline WHERE F_ID = ? AND F_AL_ID = AL_ID</statement>
+            <statement name="GetCustomer">SELECT C_BASE_AP_ID, C_BALANCE, C_SATTR00 FROM customer WHERE C_ID = ?</statement>
+            <statement name="UpdateFrequentFlyer">UPDATE frequent_flyer SET FF_IATTR10 = FF_IATTR10 + 1, FF_IATTR11 = ?, FF_IATTR12 = ?, FF_IATTR13 = ?, FF_IATTR14 = ? WHERE FF_C_ID = ? AND FF_AL_ID = ?</statement>
+            <statement name="CheckSeat">SELECT R_ID FROM reservation WHERE R_F_ID = ? and R_SEAT = ?</statement>
+            <statement name="UpdateFlight">UPDATE flight SET F_SEATS_LEFT = F_SEATS_LEFT - 1 WHERE F_ID = ?</statement>
+        </procedure>
+        <procedure name="UpdateCustomer">
+            <statement name="UpdateCustomer">UPDATE customer SET C_IATTR00 = ?, C_IATTR01 = ? WHERE C_ID = ?</statement>
+            <statement name="GetCustomer">SELECT * FROM customer WHERE C_ID = ? </statement>
+            <statement name="GetCustomerIdStr">SELECT C_ID FROM customer WHERE C_ID_STR = ? </statement>
+            <statement name="UpdatFrequentFlyers">UPDATE frequent_flyer SET FF_IATTR00 = ?, FF_IATTR01 = ? WHERE FF_C_ID = ? AND FF_AL_ID = ?</statement>
+            <statement name="GetFrequentFlyers">SELECT * FROM frequent_flyer WHERE FF_C_ID = ?</statement>
+            <statement name="GetBaseAirport">SELECT * FROM airport, country WHERE AP_ID = ? AND AP_CO_ID = CO_ID </statement>
+        </procedure>
+        <procedure name="UpdateReservation">
+            <statement name="ReserveSeat2">UPDATE reservation SET R_SEAT = ?, R_IATTR02 = ? WHERE R_ID = ? AND R_C_ID = ? AND R_F_ID = ?</statement>
+            <statement name="ReserveSeat1">UPDATE reservation SET R_SEAT = ?, R_IATTR01 = ? WHERE R_ID = ? AND R_C_ID = ? AND R_F_ID = ?</statement>
+            <statement name="ReserveSeat3">UPDATE reservation SET R_SEAT = ?, R_IATTR03 = ? WHERE R_ID = ? AND R_C_ID = ? AND R_F_ID = ?</statement>
+            <statement name="CheckCustomer">SELECT R_ID FROM reservation WHERE R_F_ID = ? AND R_C_ID = ?</statement>
+            <statement name="CheckSeat">SELECT R_ID FROM reservation WHERE R_F_ID = ? and R_SEAT = ?</statement>
+            <statement name="ReserveSeat0">UPDATE reservation SET R_SEAT = ?, R_IATTR00 = ? WHERE R_ID = ? AND R_C_ID = ? AND R_F_ID = ?</statement>
+        </procedure>
+    </dialect>
+</dialects>
+


### PR DESCRIPTION
The Wikipedia benchmark involves SQL statements which are large.  Often, when batched, these will exceed the 16 MB default single statement limit set by CockroachDB (https://www.cockroachlabs.com/docs/stable/known-limitations.html#size-limits-on-statement-input-from-sql-clients).  This change allows for a limit to be placed on the length of text inserted into the OLD_TEXT column of the TEXT table, and this value is included in the XML configuration file config/cockroachdb/sample_wikipedia_config.xml: `<oldtextmaxlen>1048576</oldtextmaxlen>`.  This, coupled with a change to the default value of batch size, to 4 (`<batchsize>4</batchsize>`), should be sufficient to get the data load running reliably without exceeding the 16 MB max. statement size limit.

If this is not set here, it defaults to `Integer.MAX_VALUE`.

After making these changes, the workload appears to run at a scale factor of 500, though there may be other factors I haven't seen which factor into this.
