### PR TITLE
New Benchmark: OtterTune Metrics

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         # BROKEN: tpch
-        benchmark: [ 'epinions', 'hyadapt', 'noop', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
+        benchmark: [ 'epinions', 'hyadapt', 'noop', 'otmetrics', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v2
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        benchmark: [ 'auctionmark', 'epinions', 'hyadapt', 'noop', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'tpch', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
+        benchmark: [ 'auctionmark', 'epinions', 'hyadapt', 'noop', 'otmetrics', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'tpch', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
     services:
       mariadb: # https://hub.docker.com/_/mariadb
         image: mariadb:latest
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        benchmark: [ 'auctionmark', 'epinions', 'hyadapt', 'noop', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
+        benchmark: [ 'auctionmark', 'epinions', 'hyadapt', 'noop', 'otmetrics', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
     services:
       mysql: # https://hub.docker.com/_/mysql
         image: mysql:latest
@@ -208,7 +208,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        benchmark: [ 'auctionmark', 'epinions', 'hyadapt', 'noop', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'tpch', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
+        benchmark: [ 'auctionmark', 'epinions', 'hyadapt', 'noop', 'otmetrics', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'tpch', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
     services:
       postgres: # https://hub.docker.com/_/postgres
         image: postgres:latest
@@ -257,7 +257,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        benchmark: [ 'auctionmark', 'epinions', 'hyadapt', 'noop', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'tpch', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
+        benchmark: [ 'auctionmark', 'epinions', 'hyadapt', 'noop', 'otmetrics', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'tpch', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
     services:
       cockroach: # https://hub.docker.com/repository/docker/timveil/cockroachdb-single-node
         image: timveil/cockroachdb-single-node:latest

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The BenchBase framework has the following benchmarks:
 * [Epinions.com](https://github.com/cmu-db/benchbase/wiki/epinions)
 * hyadapt -- pending configuration files
 * [NoOp](https://github.com/cmu-db/benchbase/wiki/NoOp)
+* [OT-Metrics](https://github.com/cmu-db/benchbase/wiki/OT-Metrics)
 * [Resource Stresser](https://github.com/cmu-db/benchbase/wiki/Resource-Stresser)
 * [SEATS](https://github.com/cmu-db/benchbase/wiki/Seats)
 * [SIBench](https://github.com/cmu-db/benchbase/wiki/SIBench)
@@ -123,7 +124,7 @@ usage: benchbase
                                 supported: [tpcc, tpch, tatp, wikipedia,
                                 resourcestresser, twitter, epinions, ycsb,
                                 seats, auctionmark, chbenchmark, voter,
-                                sibench, noop, smallbank, hyadapt]
+                                sibench, noop, smallbank, hyadapt, otmetrics]
  -c,--config <arg>              [required] Workload configuration file
     --clear <arg>               Clear all records in the database for this
                                 benchmark

--- a/config/cockroachdb/sample_otmetrics_config.xml
+++ b/config/cockroachdb/sample_otmetrics_config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<parameters>
+
+    <!-- Connection details -->
+    <type>COCKROACHDB</type>
+    <driver>org.postgresql.Driver</driver>
+    <url>jdbc:postgresql://localhost:26257/benchbase?sslmode=disable&amp;ApplicationName=otmetrics&amp;reWriteBatchedInserts=true</url>
+    <username>admin</username>
+    <password>password</password>
+    <retries>4</retries>
+
+    <batchsize>128</batchsize>
+    <scalefactor>1</scalefactor>
+
+    <!-- The workload -->
+    <terminals>1</terminals>
+    <works>
+        <work>
+            <time>60</time>
+            <rate>unlimited</rate>
+            <weights>100</weights>
+        </work>
+    </works>
+
+    <!-- Transaction Declaration -->
+    <transactiontypes>
+        <transactiontype>
+            <name>GetSessionRange</name>
+        </transactiontype>
+    </transactiontypes>
+</parameters>

--- a/config/cockroachdb/sample_otmetrics_config.xml
+++ b/config/cockroachdb/sample_otmetrics_config.xml
@@ -9,8 +9,8 @@
     <password>password</password>
     <retries>4</retries>
 
-    <batchsize>128</batchsize>
-    <scalefactor>1</scalefactor>
+    <batchsize>2048</batchsize>
+    <scalefactor>0.1</scalefactor>
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/mariadb/sample_otmetrics_config.xml
+++ b/config/mariadb/sample_otmetrics_config.xml
@@ -8,8 +8,8 @@
     <username>admin</username>
     <password>password</password>
 
-    <batchsize>2048</batchsize>
-    <scalefactor>1</scalefactor>
+    <batchsize>10000</batchsize>
+    <scalefactor>0.1</scalefactor>
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/mariadb/sample_otmetrics_config.xml
+++ b/config/mariadb/sample_otmetrics_config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<parameters>
+
+    <!-- Connection details -->
+    <type>MARIADB</type>
+    <driver>org.mariadb.jdbc.Driver</driver>
+    <url>jdbc:mariadb://localhost:3306/benchbase?useServerPrepStmts</url>
+    <username>admin</username>
+    <password>password</password>
+
+    <batchsize>2048</batchsize>
+    <scalefactor>1</scalefactor>
+
+    <!-- The workload -->
+    <terminals>1</terminals>
+    <works>
+        <work>
+            <time>60</time>
+            <rate>unlimited</rate>
+            <weights>100</weights>
+        </work>
+    </works>
+
+    <!-- Transaction Declaration -->
+    <transactiontypes>
+        <transactiontype>
+            <name>GetSessionRange</name>
+        </transactiontype>
+    </transactiontypes>
+</parameters>

--- a/config/mysql/sample_otmetrics_config.xml
+++ b/config/mysql/sample_otmetrics_config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<parameters>
+
+    <!-- Connection details -->
+    <type>MYSQL</type>
+    <driver>com.mysql.cj.jdbc.Driver</driver>
+    <url>jdbc:mysql://localhost:3306/benchbase?rewriteBatchedStatements=true&amp;sslMode=DISABLED</url>
+    <username>admin</username>
+    <password>password</password>
+
+    <batchsize>2048</batchsize>
+    <scalefactor>1</scalefactor>
+
+    <!-- The workload -->
+    <terminals>1</terminals>
+    <works>
+        <work>
+            <time>60</time>
+            <rate>unlimited</rate>
+            <weights>100</weights>
+        </work>
+    </works>
+
+    <!-- Transaction Declaration -->
+    <transactiontypes>
+        <transactiontype>
+            <name>GetSessionRange</name>
+        </transactiontype>
+    </transactiontypes>
+</parameters>

--- a/config/mysql/sample_otmetrics_config.xml
+++ b/config/mysql/sample_otmetrics_config.xml
@@ -9,7 +9,7 @@
     <password>password</password>
 
     <batchsize>2048</batchsize>
-    <scalefactor>1</scalefactor>
+    <scalefactor>0.1</scalefactor>
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/plugin.xml
+++ b/config/plugin.xml
@@ -16,4 +16,5 @@
     <plugin name="noop">com.oltpbenchmark.benchmarks.noop.NoOpBenchmark</plugin>
     <plugin name="smallbank">com.oltpbenchmark.benchmarks.smallbank.SmallBankBenchmark</plugin>
     <plugin name="hyadapt">com.oltpbenchmark.benchmarks.hyadapt.HYADAPTBenchmark</plugin>
+    <plugin name="otmetrics">com.oltpbenchmark.benchmarks.otmetrics.OTMetricsBenchmark</plugin>
 </plugins>

--- a/config/postgres/sample_otmetrics_config.xml
+++ b/config/postgres/sample_otmetrics_config.xml
@@ -9,7 +9,7 @@
     <password>password</password>
 
     <batchsize>2048</batchsize>
-    <scalefactor>1</scalefactor>
+    <scalefactor>0.1</scalefactor>
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/postgres/sample_otmetrics_config.xml
+++ b/config/postgres/sample_otmetrics_config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<parameters>
+
+    <!-- Connection details -->
+    <type>POSTGRES</type>
+    <driver>org.postgresql.Driver</driver>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=otmetrics&amp;reWriteBatchedInserts=true</url>
+    <username>admin</username>
+    <password>password</password>
+
+    <batchsize>2048</batchsize>
+    <scalefactor>1</scalefactor>
+
+    <!-- The workload -->
+    <terminals>1</terminals>
+    <works>
+        <work>
+            <time>60</time>
+            <rate>unlimited</rate>
+            <weights>100</weights>
+        </work>
+    </works>
+
+    <!-- Transaction Declaration -->
+    <transactiontypes>
+        <transactiontype>
+            <name>GetSessionRange</name>
+        </transactiontype>
+    </transactiontypes>
+</parameters>

--- a/config/sqlite/sample_otmetrics_config.xml
+++ b/config/sqlite/sample_otmetrics_config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<parameters>
+
+    <!-- Connection details -->
+    <type>SQLITE</type>
+    <driver>org.sqlite.JDBC</driver>
+    <url>jdbc:sqlite:otmetrics.db</url>
+    <isolation>TRANSACTION_SERIALIZABLE</isolation>
+    <batchsize>128</batchsize>
+    <scalefactor>0.1</scalefactor>
+
+    <!-- SQLITE only supports one writer thread -->
+    <loaderThreads>1</loaderThreads>
+
+    <!-- The workload -->
+    <terminals>1</terminals>
+    <works>
+        <work>
+            <time>60</time>
+            <rate>unlimited</rate>
+            <weights>100</weights>
+        </work>
+    </works>
+
+    <!-- Transaction Declaration -->
+    <transactiontypes>
+        <transactiontype>
+            <name>GetSessionRange</name>
+        </transactiontype>
+    </transactiontypes>
+</parameters>

--- a/config/sqlite/sample_otmetrics_config.xml
+++ b/config/sqlite/sample_otmetrics_config.xml
@@ -6,8 +6,8 @@
     <driver>org.sqlite.JDBC</driver>
     <url>jdbc:sqlite:otmetrics.db</url>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>
-    <batchsize>128</batchsize>
-    <scalefactor>0.1</scalefactor>
+    <batchsize>10000</batchsize>
+    <scalefactor>0.01</scalefactor>
 
     <!-- SQLITE only supports one writer thread -->
     <loaderThreads>1</loaderThreads>

--- a/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/OTMetricsBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/OTMetricsBenchmark.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.oltpbenchmark.benchmarks.otmetrics;
+
+import com.oltpbenchmark.WorkloadConfiguration;
+import com.oltpbenchmark.api.BenchmarkModule;
+import com.oltpbenchmark.api.Loader;
+import com.oltpbenchmark.api.Worker;
+import com.oltpbenchmark.benchmarks.otmetrics.procedures.GetSessionRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * OtterTune Metrics Timeseries Benchmark
+ * @author pavlo
+ */
+public class OTMetricsBenchmark extends BenchmarkModule {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OTMetricsBenchmark.class);
+
+    protected final int num_sources;
+    protected final int num_sessions;
+    protected final long num_observations;
+
+    public OTMetricsBenchmark(WorkloadConfiguration workConf) {
+        super(workConf);
+
+        // Compute the number of records per table.
+        this.num_sources = (int) Math.round(OTMetricsConstants.NUM_SOURCES * workConf.getScaleFactor());
+        this.num_sessions = (int) Math.round(OTMetricsConstants.NUM_SESSIONS * workConf.getScaleFactor());
+        this.num_observations = (long) Math.round(OTMetricsConstants.NUM_OBSERVATIONS * workConf.getScaleFactor());
+    }
+
+    @Override
+    protected Package getProcedurePackageImpl() {
+        return GetSessionRange.class.getPackage();
+    }
+
+    @Override
+    protected List<Worker<? extends BenchmarkModule>> makeWorkersImpl() {
+        List<Worker<? extends BenchmarkModule>> workers = new ArrayList<>();
+        for (int i = 0; i < workConf.getTerminals(); ++i) {
+            workers.add(new OTMetricsWorker(this, i));
+        }
+        return workers;
+    }
+
+    @Override
+    protected Loader<OTMetricsBenchmark> makeLoaderImpl() {
+        return new OTMetricsLoader(this);
+    }
+
+}

--- a/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/OTMetricsConstants.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/OTMetricsConstants.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.otmetrics;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+
+public abstract class OTMetricsConstants {
+
+    /**
+     * Table Names
+     */
+    public static final String TABLENAME_SOURCES = "sources";
+    public static final String TABLENAME_SESSIONS = "sessions";
+    public static final String TABLENAME_TYPES = "types";
+    public static final String TABLENAME_OBSERVATIONS = "observations";
+
+    /**
+     * Number of records per table.
+     * All of the tables in this benchmark will scale as you change the benchmark scalefactor
+     */
+    public static final int NUM_SOURCES = 100;
+    public static final int NUM_SESSIONS = 1000;
+    public static final int NUM_TYPES = 500; // FIXED SIZE
+    public static final int NUM_OBSERVATIONS = 10000;
+
+    /**
+     * All objects in the database will be created starting after this date
+     */
+    public static final LocalDateTime START_DATE = LocalDateTime.of(2022, Month.JANUARY, 1, 0, 0);
+
+}

--- a/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/OTMetricsLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/OTMetricsLoader.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2022 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.otmetrics;
+
+import com.oltpbenchmark.api.Loader;
+import com.oltpbenchmark.api.LoaderThread;
+import com.oltpbenchmark.catalog.Table;
+import com.oltpbenchmark.distributions.ZipfianGenerator;
+import com.oltpbenchmark.util.Pair;
+import com.oltpbenchmark.util.SQLUtil;
+import com.oltpbenchmark.util.TextGenerator;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * OtterTune Metrics Timeseries Benchmark
+ * @author pavlo
+ */
+public class OTMetricsLoader extends Loader<OTMetricsBenchmark> {
+
+    public OTMetricsLoader(OTMetricsBenchmark benchmark) {
+        super(benchmark);
+    }
+
+    @Override
+    public List<LoaderThread> createLoaderThreads() {
+        List<LoaderThread> threads = new ArrayList<>();
+        final int numLoaders = this.benchmark.getWorkloadConfiguration().getLoaderThreads();
+        final int loadPerThread = Math.max(this.benchmark.num_sessions / numLoaders, 1);
+
+        // SOURCES
+        final CountDownLatch sourcesLatch = new CountDownLatch(1);
+        final CountDownLatch typesLatch = new CountDownLatch(1);
+        threads.add(new LoaderThread(this.benchmark) {
+            @Override
+            public void load(Connection conn) throws SQLException {
+                loadSources(conn);
+            }
+            @Override
+            public void afterLoad() {
+                sourcesLatch.countDown();
+            }
+        });
+
+        // TYPES
+        threads.add(new LoaderThread(this.benchmark) {
+            @Override
+            public void load(Connection conn) throws SQLException {
+                loadTypes(conn);
+            }
+            @Override
+            public void afterLoad() {
+                typesLatch.countDown();
+            }
+        });
+
+        // SESSIONS
+        for (int i = 0; i < numLoaders; i++) {
+            final int lo = i * loadPerThread;
+            final int hi = Math.min(this.benchmark.num_sessions, (i + 1) * loadPerThread);
+
+            threads.add(new LoaderThread(this.benchmark) {
+                @Override
+                public void load(Connection conn) throws SQLException {
+                    loadSessions(conn, lo, hi);
+                }
+
+                @Override
+                public void beforeLoad() {
+                    try {
+                        sourcesLatch.await();
+                        typesLatch.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+
+        return threads;
+    }
+
+    private void loadSessions(Connection conn, int low, int high) throws SQLException {
+        Table catalog_tbl = this.benchmark.getCatalog().getTable(OTMetricsConstants.TABLENAME_SESSIONS);
+        String sql = SQLUtil.getInsertSQL(catalog_tbl, this.getDatabaseType());
+
+        int total = 0;
+        int batch = 0;
+
+        // SourceId/SessionId Pairs
+        List<Pair<Integer, Integer>> observations = new ArrayList<>();
+
+        try (PreparedStatement insertBatch = conn.prepareStatement(sql)) {
+            for (int i = low; i < high; i++) {
+                int offset = 1;
+
+                // ID
+                insertBatch.setInt(offset++, i);
+
+                // SOURCE_ID
+                int source_id = i % this.benchmark.num_sources;
+                insertBatch.setInt(offset++, source_id);
+
+                // AGENT
+                String agent = String.format("agent-%016d-v%d", source_id, rng().nextInt(10));
+                insertBatch.setString(offset++, agent);
+
+                // CREATED_TIME
+                // This should be the same time as the source's created_time
+                insertBatch.setTimestamp(offset++, Timestamp.valueOf(OTMetricsUtil.getCreateDateTime(source_id)));
+
+                observations.add(Pair.of(source_id, i));
+
+                insertBatch.addBatch();
+                total++;
+
+                if ((++batch % workConf.getBatchSize()) == 0) {
+                    insertBatch.executeBatch();
+                    batch = 0;
+                    insertBatch.clearBatch();
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format("Sessions %d / %d", total, this.benchmark.num_sessions));
+                    }
+                }
+            }
+            if (batch > 0) {
+                insertBatch.executeBatch();
+            }
+            LOG.debug("Loaded {} records into {}", total, catalog_tbl.getName());
+        }
+        this.addToTableCount(catalog_tbl.getName(), total);
+
+        // Load Observations
+        int total_observations = 0;
+        for (Pair<Integer, Integer> p : observations) {
+            total_observations += loadObservations(conn, p.first, p.second);
+        }
+        LOG.debug("Loaded {} records into {}", total_observations, OTMetricsConstants.TABLENAME_OBSERVATIONS);
+    }
+
+    private int loadObservations(Connection conn, int source_id, int session_id) throws SQLException {
+        Table catalog_tbl = this.benchmark.getCatalog().getTable(OTMetricsConstants.TABLENAME_OBSERVATIONS);
+        String sql = SQLUtil.getInsertSQL(catalog_tbl, this.getDatabaseType());
+
+        int total = 0;
+        int batch = 0;
+
+        // For each session_id / source_id, we will divide the # of observations that we
+        // insert into timeticks. Then for each timetick, we will insert NUM_TYPES observations
+        int timetick = 0;
+
+        int type_category = (int)Math.floor(source_id / OTMetricsConstants.NUM_TYPES);
+
+        try (PreparedStatement insertBatch = conn.prepareStatement(sql)) {
+            for (int i = 1; i <= OTMetricsConstants.NUM_OBSERVATIONS; i++) {
+                // SOURCE_ID
+                int offset = 1;
+
+                // SOURCE_ID
+                insertBatch.setInt(offset++, source_id);
+
+                // SESSION_ID
+                insertBatch.setInt(offset++, session_id);
+
+                // TYPE_ID
+                int type_id = (i % OTMetricsConstants.NUM_TYPES);
+                insertBatch.setInt(offset++, type_id + type_category);
+
+                // VALUE
+                insertBatch.setFloat(offset++, rng().nextFloat());
+
+                // CREATED_TIME
+                LocalDateTime created = OTMetricsUtil.getObservationDateTime(source_id, timetick);
+                insertBatch.setTimestamp(offset++, Timestamp.valueOf(created));
+
+                insertBatch.addBatch();
+                total++;
+
+                if ((++batch % workConf.getBatchSize()) == 0) {
+                    insertBatch.executeBatch();
+                    batch = 0;
+                    insertBatch.clearBatch();
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format("Observations %d / %d", total, this.benchmark.num_observations));
+                    }
+                }
+
+                if (type_id == 0) {
+                    timetick++;
+                }
+            } // FOR
+            if (batch > 0) {
+                insertBatch.executeBatch();
+            }
+        }
+        this.addToTableCount(catalog_tbl.getName(), total);
+        return (total);
+    }
+
+    private void loadSources(Connection conn) throws SQLException {
+        Table catalog_tbl = this.benchmark.getCatalog().getTable(OTMetricsConstants.TABLENAME_SOURCES);
+        String sql = SQLUtil.getInsertSQL(catalog_tbl, this.getDatabaseType());
+
+        int total = 0;
+        int batch = 0;
+        char[] baseStr = TextGenerator.randomChars(rng(), 100);
+
+        try (PreparedStatement insertBatch = conn.prepareStatement(sql)) {
+            for (int record = 0; record < this.benchmark.num_sources; record++) {
+                int offset = 1;
+
+                // ID
+                insertBatch.setInt(offset++, record);
+
+                // NAME
+                insertBatch.setString(offset++, String.format("source-%025d", record));
+
+                // COMMENT
+                insertBatch.setString(offset++, String.valueOf(TextGenerator.permuteText(rng(), baseStr)));
+
+                // CREATED_TIME
+                insertBatch.setTimestamp(offset++, Timestamp.valueOf(OTMetricsUtil.getCreateDateTime(record)));
+
+                insertBatch.addBatch();
+                total++;
+
+                if ((++batch % workConf.getBatchSize()) == 0) {
+                    insertBatch.executeBatch();
+                    batch = 0;
+                    insertBatch.clearBatch();
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format("Sources %d / %d", total, this.benchmark.num_sources));
+                    }
+                }
+            }
+            if (batch > 0) {
+                insertBatch.executeBatch();
+            }
+        }
+        this.addToTableCount(catalog_tbl.getName(), total);
+        LOG.info("Loaded {} records into {}", total, catalog_tbl.getName());
+    }
+
+    private void loadTypes(Connection conn) throws SQLException {
+        Table catalog_tbl = this.benchmark.getCatalog().getTable(OTMetricsConstants.TABLENAME_TYPES);
+        String sql = SQLUtil.getInsertSQL(catalog_tbl, this.getDatabaseType());
+
+        int total = 0;
+        int batch = 0;
+        char[] baseStr = TextGenerator.randomChars(rng(), 200);
+        ZipfianGenerator valueTypeZipf = new ZipfianGenerator(rng(), 8);
+
+        try (PreparedStatement insertBatch = conn.prepareStatement(sql)) {
+            for (int record = 0; record < OTMetricsConstants.NUM_TYPES; record++) {
+                int offset = 1;
+
+                // ID
+                insertBatch.setInt(offset++, record);
+
+                // CATEGORY
+                insertBatch.setInt(offset++, (int)Math.floor(record / OTMetricsConstants.NUM_TYPES));
+
+                // VALUE_TYPE
+                insertBatch.setInt(offset++, valueTypeZipf.nextInt(8));
+
+                // NAME
+                insertBatch.setString(offset++, String.format("type-%027d", record % OTMetricsConstants.NUM_TYPES));
+
+                // COMMENT
+                insertBatch.setString(offset++, String.valueOf(TextGenerator.permuteText(rng(), baseStr)));
+
+                insertBatch.addBatch();
+                total++;
+
+                if ((++batch % workConf.getBatchSize()) == 0) {
+                    insertBatch.executeBatch();
+                    batch = 0;
+                    insertBatch.clearBatch();
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format("Types %d / %d", total, OTMetricsConstants.NUM_TYPES));
+                    }
+                }
+            }
+            if (batch > 0) {
+                insertBatch.executeBatch();
+            }
+        }
+        this.addToTableCount(catalog_tbl.getName(), total);
+        LOG.info("Loaded {} records into {}", total, catalog_tbl.getName());
+    }
+}

--- a/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/OTMetricsUtil.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/OTMetricsUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.otmetrics;
+
+import java.time.LocalDateTime;
+
+public class OTMetricsUtil {
+
+    /**
+     * For a given source_id, return the starting timestamp for any
+     * session/observation in the database.
+     * @param source_id
+     * @return
+     */
+    public static LocalDateTime getCreateDateTime(int source_id) {
+        return OTMetricsConstants.START_DATE.plusHours(source_id);
+    }
+
+    /**
+     * For a given source_id and timetick within the session, return the timestamp
+     * for the observations
+     * @param source_id
+     * @param timetick
+     * @return
+     */
+    public static LocalDateTime getObservationDateTime(int source_id, int timetick) {
+        LocalDateTime base = getCreateDateTime(source_id);
+        return base.plusMinutes(timetick * 20);
+    }
+
+
+
+}

--- a/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/OTMetricsWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/OTMetricsWorker.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.otmetrics;
+
+import com.oltpbenchmark.api.Procedure.UserAbortException;
+import com.oltpbenchmark.api.TransactionType;
+import com.oltpbenchmark.api.Worker;
+import com.oltpbenchmark.benchmarks.otmetrics.procedures.GetSessionRange;
+import com.oltpbenchmark.types.TransactionStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * OtterTune Metrics Timeseries Benchmark
+ * @author pavlo
+ */
+public class OTMetricsWorker extends Worker<OTMetricsBenchmark> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OTMetricsWorker.class);
+
+    public OTMetricsWorker(OTMetricsBenchmark benchmarkModule, int id) {
+        super(benchmarkModule, id);
+    }
+
+    @Override
+    protected TransactionStatus executeWork(Connection conn, TransactionType nextTrans) throws UserAbortException, SQLException {
+        if (nextTrans.getProcedureClass().equals(GetSessionRange.class)) {
+            execGetSessionRange(conn);
+        }
+        return (TransactionStatus.SUCCESS);
+    }
+
+    public void execGetSessionRange(Connection conn) throws SQLException {
+        int session_low = rng().nextInt(this.getBenchmark().num_sessions);
+        int session_high =  session_low + rng().nextInt(5) * this.getBenchmark().num_sources;
+        int source_id = session_low % this.getBenchmark().num_sources;
+
+        int type_category = (int)Math.floor(source_id / OTMetricsConstants.NUM_TYPES);
+        int type_id = (rng().nextInt(OTMetricsConstants.NUM_TYPES) % OTMetricsConstants.NUM_TYPES);
+        int num_types = rng().nextInt(3) + 1;
+        int types[] = new int[num_types];
+        for (int i = 0; i < types.length; i++) {
+            types[i] = type_id + type_category + i;
+        };
+
+        GetSessionRange proc = this.getProcedure(GetSessionRange.class);
+        List<Object[]> result = proc.run(conn, source_id, session_low, session_high, types);
+
+        if (LOG.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("source_id=").append(source_id).append(" ");
+            sb.append("session_low=").append(session_low).append(" ");
+            sb.append("session_high=").append(session_high).append(" ");
+            sb.append("type_id=").append(Arrays.toString(types)).append(" ");
+            sb.append(" -> ").append(result.size()).append(" results");
+            LOG.debug(sb.toString());
+        }
+    }
+
+
+}

--- a/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/procedures/GetSessionRange.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/procedures/GetSessionRange.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.otmetrics.procedures;
+
+import com.oltpbenchmark.api.Procedure;
+import com.oltpbenchmark.api.SQLStmt;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetSessionRange extends Procedure {
+
+    /**
+     * We do it this way because not all JDBC drivers support using arrays to fill in var-length parameters
+     */
+    private final String baseSQL =
+            "SELECT * FROM observations" +
+            " WHERE source_id = ?" +
+            "   AND session_id >= ?" +
+            "   AND session_id <= ?" +
+            "   AND type_id IN (%s)" +
+            " ORDER BY created_time";
+    public final SQLStmt RangeQuery1 = new SQLStmt(String.format(baseSQL, "?"));
+    public final SQLStmt RangeQuery2 = new SQLStmt(String.format(baseSQL, "?, ?"));
+    public final SQLStmt RangeQuery3 = new SQLStmt(String.format(baseSQL, "?, ?, ?"));
+
+    public List<Object[]> run(Connection conn, int source_id, int session_low, int session_high, int type_ids[]) throws SQLException {
+        final List<Object[]> finalResults = new ArrayList<>();
+
+        PreparedStatement stmt;
+        switch (type_ids.length) {
+            case 1:
+                stmt = this.getPreparedStatement(conn, RangeQuery1, source_id, session_low, session_high, type_ids[0]);
+                break;
+            case 2:
+                stmt = this.getPreparedStatement(conn, RangeQuery2, source_id, session_low, session_high, type_ids[0], type_ids[1]);
+                break;
+            case 3:
+                stmt = this.getPreparedStatement(conn, RangeQuery3, source_id, session_low, session_high, type_ids[0], type_ids[1], type_ids[2]);
+                break;
+            default:
+                throw new RuntimeException("Unexpected type_id array length of " + type_ids.length);
+        } // SWITCH
+        assert(stmt != null);
+
+        // Bombs away!
+        try (ResultSet results = stmt.executeQuery()) {
+            while (results.next()) {
+                int cols = results.getMetaData().getColumnCount();
+                Object[] arr = new Object[cols];
+                for (int i = 0; i < cols; i++) {
+                    arr[i] = results.getObject(i + 1).toString();
+                }
+                finalResults.add(arr);
+            }
+        }
+        return (finalResults);
+    }
+
+}

--- a/src/main/resources/benchmarks/otmetrics/ddl-generic.sql
+++ b/src/main/resources/benchmarks/otmetrics/ddl-generic.sql
@@ -36,4 +36,4 @@ CREATE TABLE observations (
   value DOUBLE PRECISION NOT NULL,
   created_time TIMESTAMP NOT NULL
 );
-CREATE INDEX idx_observations_source_session ON observations (source_id, session_id);
+CREATE INDEX idx_observations_source_session ON observations (source_id, session_id, type_id);

--- a/src/main/resources/benchmarks/otmetrics/ddl-generic.sql
+++ b/src/main/resources/benchmarks/otmetrics/ddl-generic.sql
@@ -1,0 +1,39 @@
+DROP TABLE IF EXISTS observations;
+DROP TABLE IF exists types;
+DROP TABLE IF EXISTS sessions;
+DROP TABLE IF exists sources;
+
+CREATE TABLE sources (
+    id INTEGER NOT NULL,
+    name VARCHAR(128) NOT NULL UNIQUE,
+    comment varchar(256) DEFAULT NULL,
+    created_time TIMESTAMP NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE types (
+    id INTEGER NOT NULL,
+    category INTEGER NOT NULL,
+    value_type INTEGER NOT NULL,
+    name VARCHAR(64) NOT NULL,
+    comment varchar(256) DEFAULT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (category, name)
+);
+
+CREATE TABLE sessions (
+    id INTEGER NOT NULL,
+    source_id INTEGER NOT NULL REFERENCES sources (id),
+    agent VARCHAR(32) NOT NULL,
+    created_time TIMESTAMP NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE observations (
+  source_id INTEGER NOT NULL REFERENCES sources (id),
+  session_id INTEGER NOT NULL REFERENCES sessions (id),
+  type_id INTEGER NOT NULL REFERENCES types (id),
+  value DOUBLE PRECISION NOT NULL,
+  created_time TIMESTAMP NOT NULL
+);
+CREATE INDEX idx_observations_source_session ON observations (source_id, session_id);

--- a/src/test/java/com/oltpbenchmark/benchmarks/otmetrics/TestOTMetricsBenchmark.java
+++ b/src/test/java/com/oltpbenchmark/benchmarks/otmetrics/TestOTMetricsBenchmark.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.otmetrics;
+
+import com.oltpbenchmark.api.AbstractTestBenchmarkModule;
+import com.oltpbenchmark.api.Procedure;
+import com.oltpbenchmark.benchmarks.otmetrics.procedures.GetSessionRange;
+
+import java.util.List;
+
+public class TestOTMetricsBenchmark extends AbstractTestBenchmarkModule<OTMetricsBenchmark> {
+
+    public static final List<Class<? extends Procedure>> PROCEDURE_CLASSES = List.of(
+            GetSessionRange.class
+    );
+
+    @Override
+    public List<Class<? extends Procedure>> procedures() {
+        return TestOTMetricsBenchmark.PROCEDURE_CLASSES;
+    }
+
+    @Override
+    public Class<OTMetricsBenchmark> benchmarkClass() {
+        return OTMetricsBenchmark.class;
+    }
+
+}

--- a/src/test/java/com/oltpbenchmark/benchmarks/otmetrics/TestOTMetricsLoader.java
+++ b/src/test/java/com/oltpbenchmark/benchmarks/otmetrics/TestOTMetricsLoader.java
@@ -1,0 +1,44 @@
+/******************************************************************************
+ *  Copyright 2015 by OLTPBenchmark Project                                   *
+ *                                                                            *
+ *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  you may not use this file except in compliance with the License.          *
+ *  You may obtain a copy of the License at                                   *
+ *                                                                            *
+ *    http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                            *
+ *  Unless required by applicable law or agreed to in writing, software       *
+ *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ *  See the License for the specific language governing permissions and       *
+ *  limitations under the License.                                            *
+ ******************************************************************************/
+
+package com.oltpbenchmark.benchmarks.otmetrics;
+
+import com.oltpbenchmark.api.AbstractTestLoader;
+import com.oltpbenchmark.api.Procedure;
+
+import java.util.List;
+
+public class TestOTMetricsLoader extends AbstractTestLoader<OTMetricsBenchmark> {
+
+    private static final String[] IGNORE = {
+
+    };
+
+    @Override
+    public List<Class<? extends Procedure>> procedures() {
+        return TestOTMetricsBenchmark.PROCEDURE_CLASSES;
+    }
+
+    @Override
+    public Class<OTMetricsBenchmark> benchmarkClass() {
+        return OTMetricsBenchmark.class;
+    }
+
+    @Override
+    public List<String> ignorableTables() {
+        return List.of(IGNORE);
+    }
+}

--- a/src/test/java/com/oltpbenchmark/benchmarks/otmetrics/TestOTMetricsWorker.java
+++ b/src/test/java/com/oltpbenchmark/benchmarks/otmetrics/TestOTMetricsWorker.java
@@ -1,0 +1,19 @@
+package com.oltpbenchmark.benchmarks.otmetrics;
+
+import com.oltpbenchmark.api.AbstractTestWorker;
+import com.oltpbenchmark.api.Procedure;
+
+import java.util.List;
+
+public class TestOTMetricsWorker extends AbstractTestWorker<OTMetricsBenchmark> {
+
+    @Override
+    public List<Class<? extends Procedure>> procedures() {
+        return TestOTMetricsBenchmark.PROCEDURE_CLASSES;
+    }
+
+    @Override
+    public Class<OTMetricsBenchmark> benchmarkClass() {
+        return OTMetricsBenchmark.class;
+    }
+}


### PR DESCRIPTION
This was originally the "TimeseriesBenchmark" that I wrote for Project1 in the [15-799 course](https://15799.courses.cs.cmu.edu/spring2022/project1.html). I have ported it over to the latest version of BenchBase and renamed it to `otmetrics` (OtterTune Metrics). This workload is based on the internal metrics collection architecture of OtterTune and a specific query that we use to generate charts. After I merge this, @haonanw98 will add the ability to insert new observations.

https://youtu.be/ZaNFPqQ6tsQ
