### PR TITLE
Docker build as root fixups

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -386,7 +386,8 @@ jobs:
           DOCKER_BUILDKIT: 1
           BENCHBASE_PROFILES: 'cockroachdb mariadb mysql postgres spanner phoenix sqlserver'
         run: |
-          docker build --build-arg "BENCHBASE_PROFILES=$BENCHBASE_PROFILES" --build-arg TEST_TARGET=test --build-arg UID=$UID --build-arg GID=$UID \
+          docker build --build-arg "BENCHBASE_PROFILES=$BENCHBASE_PROFILES" --build-arg TEST_TARGET=test \
+            --build-arg CONTAINERUSER_UID=$UID --build-arg CONTAINERUSER_GID=$UID \
             -t benchbase:latest -f ./docker/benchbase/Dockerfile --target fullimage .
       - name: Run basic benchbase test from the docker image against postgres test DB
         env:

--- a/docker/benchbase/Dockerfile
+++ b/docker/benchbase/Dockerfile
@@ -31,7 +31,7 @@ FROM --platform=linux maven:3.8.5-eclipse-temurin-17 AS devcontainer
 ARG UID=1000
 ARG GID=1000
 RUN addgroup --gid ${GID} containergroup \
-    && adduser --disabled-password --gecos 'Container User' --uid ${UID} --gid ${GID} containeruser
+    && adduser --disabled-password --gecos 'Container User' --uid ${UID} --gid ${GID} containeruser || true
 RUN mkdir -p /benchbase/results && chown -R containeruser:containergroup /benchbase/
 USER containeruser
 ENV MAVEN_CONFIG=/home/containeruser/.m2

--- a/docker/benchbase/Dockerfile
+++ b/docker/benchbase/Dockerfile
@@ -28,10 +28,10 @@ FROM --platform=linux maven:3.8.5-eclipse-temurin-17 AS devcontainer
 
 # Add a containeruser that allows vscode/codespaces to map the local host user
 # (often uid 1000) to some non-root user inside the container.
-ARG UID=1000
-ARG GID=1000
-RUN addgroup --gid ${GID} containergroup \
-    && adduser --disabled-password --gecos 'Container User' --uid ${UID} --gid ${GID} containeruser || true
+ARG CONTAINERUSER_UID=1000
+ARG CONTAINERUSER_GID=1000
+RUN addgroup --gid ${CONTAINERUSER_GID} containergroup \
+    && adduser --disabled-password --gecos 'Container User' --uid ${CONTAINERUSER_UID} --gid ${CONTAINERUSER_GID} containeruser || true
 RUN mkdir -p /benchbase/results && chown -R containeruser:containergroup /benchbase/
 USER containeruser
 ENV MAVEN_CONFIG=/home/containeruser/.m2

--- a/docker/benchbase/Dockerfile
+++ b/docker/benchbase/Dockerfile
@@ -30,8 +30,9 @@ FROM --platform=linux maven:3.8.5-eclipse-temurin-17 AS devcontainer
 # (often uid 1000) to some non-root user inside the container.
 ARG CONTAINERUSER_UID=1000
 ARG CONTAINERUSER_GID=1000
-RUN addgroup --gid ${CONTAINERUSER_GID} containergroup \
-    && adduser --disabled-password --gecos 'Container User' --uid ${CONTAINERUSER_UID} --gid ${CONTAINERUSER_GID} containeruser || true
+RUN groupadd --non-unique --gid ${CONTAINERUSER_GID} containergroup \
+    && useradd --non-unique --create-home --no-user-group --comment 'Container User' \
+        --uid ${CONTAINERUSER_UID} --gid ${CONTAINERUSER_GID} containeruser
 RUN mkdir -p /benchbase/results && chown -R containeruser:containergroup /benchbase/
 USER containeruser
 ENV MAVEN_CONFIG=/home/containeruser/.m2

--- a/docker/benchbase/build-full-image.sh
+++ b/docker/benchbase/build-full-image.sh
@@ -13,12 +13,12 @@ http_proxy_port=''
 https_proxy_host=''
 https_proxy_port=''
 
-if echo "$http_proxy" | egrep -q 'http[s]?://[^:]+:[0-9]+[/]?$'; then
+if echo "${http_proxy:-}" | egrep -q 'http[s]?://[^:]+:[0-9]+[/]?$'; then
     http_proxy_host=$(echo "$http_proxy" | sed -r -e 's|^http[s]?://([^:]+):([0-9]+)[/]?$|\1|')
     http_proxy_port=$(echo "$http_proxy" | sed -r -e 's|^http[s]?://([^:]+):([0-9]+)[/]?$|\2|')
 fi
 
-if echo "$https_proxy" | egrep -q 'http[s]?://[^:]+:[0-9]+[/]?$'; then
+if echo "${https_proxy:-}" | egrep -q 'http[s]?://[^:]+:[0-9]+[/]?$'; then
     https_proxy_host=$(echo "$https_proxy" | sed -r -e 's|^http[s]?://([^:]+):([0-9]+)[/]?$|\1|')
     https_proxy_port=$(echo "$https_proxy" | sed -r -e 's|^http[s]?://([^:]+):([0-9]+)[/]?$|\2|')
 fi

--- a/docker/benchbase/build-full-image.sh
+++ b/docker/benchbase/build-full-image.sh
@@ -38,7 +38,7 @@ else
 fi
 
 CONTAINERUSER_UID="${CONTAINERUSER_UID:-$UID}"
-if [ "$CONTAINERUSER_UID" -eq 0 ] && [ -n "$SUDO_UID" ]; then
+if [ "$CONTAINERUSER_UID" -eq 0 ] && [ -n "${SUDO_UID:-}" ]; then
     CONTAINERUSER_UID="$SUDO_UID"
 fi
 CONTAINERUSER_GID=${CONTAINERUSER_GID:-$(getent passwd "$CONTAINERUSER_UID" | cut -d: -f4)}


### PR DESCRIPTION
Fixes #193 

containeruser `UID` `GID` fixups for when using the script to build as root.

Use `CONTAINERUSER_UID` `CONTAINERUSER_GID` instead of `UID` `GID` directly.

Allow those to be supplied as environment variable overrides (e.g. `CONTAINERUSER_UID=1234 ./build-full-image.sh`)

If not available, default to `UID` `GID` as before.

If those are `0` (root, which already exists in the container), then try
to look at the `SUDO_UID` environment variable.

Also fixes up the Dockerfile to support creating a `containeruser` with an overlapping uid (e.g. `0`) in case all of the above workarounds are insufficient.