### PR TITLE
Add `newConnectionPerTxn` config option and implementation

### DIFF
--- a/src/main/java/com/oltpbenchmark/DBWorkload.java
+++ b/src/main/java/com/oltpbenchmark/DBWorkload.java
@@ -125,7 +125,7 @@ public class DBWorkload {
             wrkld.setRandomSeed(xmlConfig.getInt("randomSeed", -1));
             wrkld.setBatchSize(xmlConfig.getInt("batchsize", 128));
             wrkld.setMaxRetries(xmlConfig.getInt("retries", 3));
-            wrkld.setNewConnections(xmlConfig.getBoolean("newConnections", false));
+            wrkld.setNewConnectionPerTxn(xmlConfig.getBoolean("newConnectionPerTxn", false));
 
             int terminals = xmlConfig.getInt("terminals[not(@bench)]", 0);
             terminals = xmlConfig.getInt("terminals" + pluginTest, terminals);
@@ -171,7 +171,7 @@ public class DBWorkload {
             initDebug.put("Batch Size", wrkld.getBatchSize());
             initDebug.put("Scale Factor", wrkld.getScaleFactor());
             initDebug.put("Terminals", wrkld.getTerminals());
-            initDebug.put("New Connections", wrkld.getNewConnections());
+            initDebug.put("New Connection Per Txn", wrkld.getNewConnectionPerTxn());
 
             if (selectivity != -1) {
                 initDebug.put("Selectivity", selectivity);

--- a/src/main/java/com/oltpbenchmark/DBWorkload.java
+++ b/src/main/java/com/oltpbenchmark/DBWorkload.java
@@ -170,6 +170,7 @@ public class DBWorkload {
             initDebug.put("Batch Size", wrkld.getBatchSize());
             initDebug.put("Scale Factor", wrkld.getScaleFactor());
             initDebug.put("Terminals", wrkld.getTerminals());
+            initDebug.put("New Connections", wrkld.getNewConnections());
 
             if (selectivity != -1) {
                 initDebug.put("Selectivity", selectivity);

--- a/src/main/java/com/oltpbenchmark/DBWorkload.java
+++ b/src/main/java/com/oltpbenchmark/DBWorkload.java
@@ -125,6 +125,7 @@ public class DBWorkload {
             wrkld.setRandomSeed(xmlConfig.getInt("randomSeed", -1));
             wrkld.setBatchSize(xmlConfig.getInt("batchsize", 128));
             wrkld.setMaxRetries(xmlConfig.getInt("retries", 3));
+            wrkld.setNewConnections(xmlConfig.getBoolean("newConnections", false));
 
             int terminals = xmlConfig.getInt("terminals[not(@bench)]", 0);
             terminals = xmlConfig.getInt("terminals" + pluginTest, terminals);

--- a/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
@@ -140,6 +140,8 @@ public class WorkloadConfiguration {
     }
 
 
+
+
     /**
      * The number of loader threads that the framework is allowed to use.
      *
@@ -310,24 +312,24 @@ public class WorkloadConfiguration {
     @Override
     public String toString() {
         return "WorkloadConfiguration{" +
-            "phases=" + phases +
-            ", databaseType=" + databaseType +
-            ", benchmarkName='" + benchmarkName + '\'' +
-            ", url='" + url + '\'' +
-            ", username='" + username + '\'' +
-            ", password='" + password + '\'' +
-            ", driverClass='" + driverClass + '\'' +
-            ", batchSize=" + batchSize +
-            ", maxRetries=" + maxRetries +
-            ", scaleFactor=" + scaleFactor +
-            ", selectivity=" + selectivity +
-            ", terminals=" + terminals +
-            ", loaderThreads=" + loaderThreads +
-            ", workloadState=" + workloadState +
-            ", transTypes=" + transTypes +
-            ", isolationMode=" + isolationMode +
-            ", dataDir='" + dataDir + '\'' +
-            ", newConnectionPerTxn='" + newConnectionPerTxn + '\'' +
-            '}';
+               "phases=" + phases +
+               ", databaseType=" + databaseType +
+               ", benchmarkName='" + benchmarkName + '\'' +
+               ", url='" + url + '\'' +
+               ", username='" + username + '\'' +
+               ", password='" + password + '\'' +
+               ", driverClass='" + driverClass + '\'' +
+               ", batchSize=" + batchSize +
+               ", maxRetries=" + maxRetries +
+               ", scaleFactor=" + scaleFactor +
+               ", selectivity=" + selectivity +
+               ", terminals=" + terminals +
+               ", loaderThreads=" + loaderThreads +
+               ", workloadState=" + workloadState +
+               ", transTypes=" + transTypes +
+               ", isolationMode=" + isolationMode +
+               ", dataDir='" + dataDir + '\'' +
+               ", newConnectionPerTxn='" + newConnectionPerTxn + '\'' +
+               '}';
     }
 }

--- a/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
@@ -50,7 +50,7 @@ public class WorkloadConfiguration {
     private String dataDir = null;
     private String ddlPath = null;
 
-    private boolean newConnections = false;
+    private boolean newConnectionPerTxn = false;
 
     public String getBenchmarkName() {
         return benchmarkName;
@@ -120,9 +120,13 @@ public class WorkloadConfiguration {
         this.maxRetries = maxRetries;
     }
 
-    public boolean getNewConnections() { return newConnections; }
+    public boolean getNewConnectionPerTxn() {
+        return newConnectionPerTxn;
+    }
 
-    public void setNewConnections(boolean newConnections) { this.newConnections = newConnections; }
+    public void setNewConnectionPerTxn(boolean newConnectionPerTxn) {
+        this.newConnectionPerTxn = newConnectionPerTxn;
+    }
 
     /**
      * Initiate a new benchmark and workload state
@@ -134,8 +138,6 @@ public class WorkloadConfiguration {
     public void addPhase(int id, int time, int warmup, int rate, List<Double> weights, boolean rateLimited, boolean disabled, boolean serial, boolean timed, int active_terminals, Phase.Arrival arrival) {
         phases.add(new Phase(benchmarkName, id, time, warmup, rate, weights, rateLimited, disabled, serial, timed, active_terminals, arrival));
     }
-
-
 
 
     /**
@@ -308,24 +310,24 @@ public class WorkloadConfiguration {
     @Override
     public String toString() {
         return "WorkloadConfiguration{" +
-               "phases=" + phases +
-               ", databaseType=" + databaseType +
-               ", benchmarkName='" + benchmarkName + '\'' +
-               ", url='" + url + '\'' +
-               ", username='" + username + '\'' +
-               ", password='" + password + '\'' +
-               ", driverClass='" + driverClass + '\'' +
-               ", batchSize=" + batchSize +
-               ", maxRetries=" + maxRetries +
-               ", scaleFactor=" + scaleFactor +
-               ", selectivity=" + selectivity +
-               ", terminals=" + terminals +
-               ", loaderThreads=" + loaderThreads +
-               ", workloadState=" + workloadState +
-               ", transTypes=" + transTypes +
-               ", isolationMode=" + isolationMode +
-               ", dataDir='" + dataDir + '\'' + 
-               ", newConnections='" + newConnections + '\'' +
-               '}';
+            "phases=" + phases +
+            ", databaseType=" + databaseType +
+            ", benchmarkName='" + benchmarkName + '\'' +
+            ", url='" + url + '\'' +
+            ", username='" + username + '\'' +
+            ", password='" + password + '\'' +
+            ", driverClass='" + driverClass + '\'' +
+            ", batchSize=" + batchSize +
+            ", maxRetries=" + maxRetries +
+            ", scaleFactor=" + scaleFactor +
+            ", selectivity=" + selectivity +
+            ", terminals=" + terminals +
+            ", loaderThreads=" + loaderThreads +
+            ", workloadState=" + workloadState +
+            ", transTypes=" + transTypes +
+            ", isolationMode=" + isolationMode +
+            ", dataDir='" + dataDir + '\'' +
+            ", newConnectionPerTxn='" + newConnectionPerTxn + '\'' +
+            '}';
     }
 }

--- a/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
@@ -50,6 +50,10 @@ public class WorkloadConfiguration {
     private String dataDir = null;
     private String ddlPath = null;
 
+    /**
+     * If true, establish a new connection for each transaction, otherwise use one persistent connection per client
+     * session. This is useful to measure the connection overhead.
+     */
     private boolean newConnectionPerTxn = false;
 
     public String getBenchmarkName() {
@@ -120,10 +124,19 @@ public class WorkloadConfiguration {
         this.maxRetries = maxRetries;
     }
 
+    /**
+     * @return @see newConnectionPerTxn member docs for behavior.
+     */
     public boolean getNewConnectionPerTxn() {
         return newConnectionPerTxn;
     }
 
+    /**
+     * Used by the configuration loader at startup. Changing it any other time is probably dangeroues. @see
+     * newConnectionPerTxn member docs for behavior.
+     *
+     * @param newConnectionPerTxn
+     */
     public void setNewConnectionPerTxn(boolean newConnectionPerTxn) {
         this.newConnectionPerTxn = newConnectionPerTxn;
     }
@@ -329,7 +342,6 @@ public class WorkloadConfiguration {
                ", transTypes=" + transTypes +
                ", isolationMode=" + isolationMode +
                ", dataDir='" + dataDir + '\'' +
-               ", newConnectionPerTxn='" + newConnectionPerTxn + '\'' +
                '}';
     }
 }

--- a/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
@@ -49,6 +49,8 @@ public class WorkloadConfiguration {
     private int isolationMode = Connection.TRANSACTION_SERIALIZABLE;
     private String dataDir = null;
 
+    private boolean newConnections = false;
+
     public String getBenchmarkName() {
         return benchmarkName;
     }
@@ -116,6 +118,10 @@ public class WorkloadConfiguration {
     public void setMaxRetries(int maxRetries) {
         this.maxRetries = maxRetries;
     }
+
+    public boolean getNewConnections() { return newConnections; }
+
+    public void setNewConnections(boolean newConnections) { this.newConnections = newConnections; }
 
     /**
      * Initiate a new benchmark and workload state
@@ -303,7 +309,8 @@ public class WorkloadConfiguration {
                ", workloadState=" + workloadState +
                ", transTypes=" + transTypes +
                ", isolationMode=" + isolationMode +
-               ", dataDir='" + dataDir + '\'' +
+               ", dataDir='" + dataDir + '\'' + 
+               ", newConnections='" + newConnections + '\'' +
                '}';
     }
 }

--- a/src/main/java/com/oltpbenchmark/WorkloadState.java
+++ b/src/main/java/com/oltpbenchmark/WorkloadState.java
@@ -59,32 +59,29 @@ public class WorkloadState {
      * Add a request to do work.
      */
     public void addToQueue(int amount, boolean resetQueues) {
+        int workAdded = 0;
+        
         synchronized (this) {
             if (resetQueues) {
                 workQueue.clear();
             }
 
-
             // Only use the work queue if the phase is enabled and rate limited.
             if (currentPhase == null || currentPhase.isDisabled()
                     || !currentPhase.isRateLimited() || currentPhase.isSerial()) {
                 return;
-            } else {
-                // Add the specified number of procedures to the end of the queue.
-                for (int i = 0; i < amount; ++i) {
-                    workQueue.add(new SubmittedProcedure(currentPhase.chooseTransaction()));
-                }
             }
-
-            // Can't keep up with current rate? Remove the oldest transactions
-            // (from the front of the queue).
-            while (workQueue.size() > RATE_QUEUE_LIMIT) {
-                workQueue.remove();
+            
+            // Add the specified number of procedures to the end of the queue.
+            // If we can't keep up with current rate, truncate transactions
+            for (int i = 0; i < amount && workQueue.size() <= RATE_QUEUE_LIMIT; ++i) {
+                workQueue.add(new SubmittedProcedure(currentPhase.chooseTransaction()));
+                workAdded++;
             }
 
             // Wake up sleeping workers to deal with the new work.
-            int numToWake = Math.min(amount, workersWaiting);
-            for (int i = 0; i < numToWake; ++i) {
+            int numToWake = Math.min(workAdded, workersWaiting);
+            while (numToWake-- > 0) {
                 this.notify();
             }
         }

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -50,7 +50,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
     private final int id;
     private final T benchmark;
-    protected final Connection conn;
+    protected Connection conn = null;
     protected final WorkloadConfiguration configuration;
     protected final TransactionTypes transactionTypes;
     protected final Map<TransactionType, Procedure> procedures = new HashMap<>();
@@ -74,12 +74,14 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
         this.currStatement = null;
         this.transactionTypes = this.configuration.getTransTypes();
 
-        try {
-            this.conn = this.benchmark.makeConnection();
-            this.conn.setAutoCommit(false);
-            this.conn.setTransactionIsolation(this.configuration.getIsolationMode());
-        } catch (SQLException ex) {
-            throw new RuntimeException("Failed to connect to database", ex);
+        if (!this.configuration.getNewConnections()) {
+            try {
+                this.conn = this.benchmark.makeConnection();
+                this.conn.setAutoCommit(false);
+                this.conn.setTransactionIsolation(this.configuration.getIsolationMode());
+            } catch (SQLException ex) {
+                throw new RuntimeException("Failed to connect to database", ex);
+            }
         }
 
         // Generate all the Procedures that we're going to need
@@ -370,7 +372,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * implementing worker should return the TransactionType handle that was
      * executed.
      *
-     * @param databaseType TODO
+     * @param databaseType    TODO
      * @param transactionType TODO
      */
     protected final void doWork(DatabaseType databaseType, TransactionType transactionType) {
@@ -382,6 +384,20 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
             while (retryCount < maxRetryCount && this.workloadState.getGlobalState() != State.DONE) {
 
                 TransactionStatus status = TransactionStatus.UNKNOWN;
+
+                if (this.conn == null) {
+                    try {
+                        this.conn = this.benchmarkModule.makeConnection();
+                        this.conn.setAutoCommit(false);
+                        this.conn.setTransactionIsolation(this.configuration.getIsolationMode());
+                    } catch (SQLException ex) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(String.format("%s failed to open a connection...", this));
+                        }
+                        retryCount++;
+                        continue;
+                    }
+                }
 
                 try {
 
@@ -430,6 +446,14 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                     }
 
                 } finally {
+                    if (this.configuration.getNewConnections()) {
+                        try {
+                            this.conn.close();
+                            this.conn = null;
+                        } catch (SQLException e) {
+                            LOG.error("Connection couldn't be closed.", e);
+                        }
+                    }
 
                     switch (status) {
                         case UNKNOWN -> this.txnUnknown.put(transactionType);
@@ -503,10 +527,12 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * Called at the end of the test to do any clean up that may be required.
      */
     public void tearDown() {
-        try {
-            conn.close();
-        } catch (SQLException e) {
-            LOG.error("Connection couldn't be closed.", e);
+        if (!this.configuration.getNewConnections()) {
+            try {
+                conn.close();
+            } catch (SQLException e) {
+                LOG.error("Connection couldn't be closed.", e);
+            }
         }
     }
 

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -446,7 +446,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                     }
 
                 } finally {
-                    if (this.configuration.getNewConnectionPerTxn()) {
+                    if (this.configuration.getNewConnectionPerTxn() && this.conn != null) {
                         try {
                             this.conn.close();
                             this.conn = null;
@@ -527,7 +527,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * Called at the end of the test to do any clean up that may be required.
      */
     public void tearDown() {
-        if (!this.configuration.getNewConnectionPerTxn()) {
+        if (!this.configuration.getNewConnectionPerTxn() && this.conn != null) {
             try {
                 conn.close();
             } catch (SQLException e) {

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -387,7 +387,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
                 if (this.conn == null) {
                     try {
-                        this.conn = this.benchmarkModule.makeConnection();
+                        this.conn = this.benchmark.makeConnection();
                         this.conn.setAutoCommit(false);
                         this.conn.setTransactionIsolation(this.configuration.getIsolationMode());
                     } catch (SQLException ex) {

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -74,7 +74,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
         this.currStatement = null;
         this.transactionTypes = this.configuration.getTransTypes();
 
-        if (!this.configuration.getNewConnections()) {
+        if (!this.configuration.getNewConnectionPerTxn()) {
             try {
                 this.conn = this.benchmark.makeConnection();
                 this.conn.setAutoCommit(false);
@@ -446,7 +446,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                     }
 
                 } finally {
-                    if (this.configuration.getNewConnections()) {
+                    if (this.configuration.getNewConnectionPerTxn()) {
                         try {
                             this.conn.close();
                             this.conn = null;
@@ -527,7 +527,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * Called at the end of the test to do any clean up that may be required.
      */
     public void tearDown() {
-        if (!this.configuration.getNewConnections()) {
+        if (!this.configuration.getNewConnectionPerTxn()) {
             try {
                 conn.close();
             } catch (SQLException e) {

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -372,7 +372,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * implementing worker should return the TransactionType handle that was
      * executed.
      *
-     * @param databaseType    TODO
+     * @param databaseType TODO
      * @param transactionType TODO
      */
     protected final void doWork(DatabaseType databaseType, TransactionType transactionType) {


### PR DESCRIPTION
[pgbench](https://www.postgresql.org/docs/current/pgbench.html) has `-c` or `--connect` flag with the following behavior:
> Establish a new connection for each transaction, rather than doing it just once per client session. This is useful to measure the connection overhead.

This PR attempts to replicate that behavior with a `newConnectionPerTxn` config option.

This might be my first BenchBase PR so please double-check me on naming/code conventions for this repo. I'll also look into the test infrastructure a bit to see how easy it is to add a test scenario for this, so consider this PR WIP for the moment.