### PR TITLE
null check `postPhase` in `Worker.run` to resolve race condition at terminate

### DIFF
--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -378,7 +378,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * implementing worker should return the TransactionType handle that was
      * executed.
      *
-     * @param databaseType    TODO
+     * @param databaseType TODO
      * @param transactionType TODO
      */
     protected final void doWork(DatabaseType databaseType, TransactionType transactionType) {

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -296,7 +296,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
                         if (postPhase == null) {
                             // Need a null check on postPhase since current phase being null is used in WorkloadState
-                            // and BenchmarkState as the indication that the benchmark is over. However, there's a race
+                            // and ThreadBench as the indication that the benchmark is over. However, there's a race
                             // condition with postState not being changed from MEASURE to DONE yet, so we entered the
                             // switch. In this scenario, just break from the switch.
                             break;

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -297,7 +297,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                         if (postPhase == null) {
                             // Need a null check on postPhase since current phase being null is used in WorkloadState
                             // and BenchmarkState as the indication that the benchmark is over. However, there's a race
-                            // condition with postState not being changes to DONE from MEASURE yet, so we entered the
+                            // condition with postState not being changed from MEASURE to DONE yet, so we entered the
                             // switch. In this scenario, just break from the switch.
                             break;
                         }


### PR DESCRIPTION
`ThreadBench` and `WorkloadState` rely on `WorkloadState.currentPhase` being `null` as the indicator that the benchmark is over. For example: https://github.com/cmu-db/benchbase/blob/1c43cad2a9b47611806f1e101d7e4b636ae8f105/src/main/java/com/oltpbenchmark/WorkloadState.java#L205-L206

However, `Worker` relies on `BenchmarkState.state` being `DONE` as its indicator that the benchmark is over. For example, this switch assumes that because state is still `MEASURE` that the benchmark is still running and that the result of `getCurrentPhase` is safe to access: https://github.com/cmu-db/benchbase/blob/1c43cad2a9b47611806f1e101d7e4b636ae8f105/src/main/java/com/oltpbenchmark/api/Worker.java#L288-L296

The race occurs between the previously mentioned switch in `Worker` and in `ThreadBench` where this line advances to the next phase, which in the case of the benchmark ending, puts the current phase to `null`. If a `Worker` tries to read the current phase before the state is set to `DONE` when `ThreadBench` calls `startCoolDown()` then benchbase goes boom. https://github.com/cmu-db/benchbase/blob/1c43cad2a9b47611806f1e101d7e4b636ae8f105/src/main/java/com/oltpbenchmark/ThreadBench.java#L222-L229

I believe the easiest fix here is a documented `null` check in `Worker`. Maybe there's a better way to sync up the indicators of the benchmark ending between all of these classes, but this seems like the lowest risk change.

Fixes #37.