### PR TITLE
Add Egress benchmark

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -222,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        benchmark: [ 'auctionmark', 'epinions', 'hyadapt', 'noop', 'otmetrics', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'tpch', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
+        benchmark: [ 'auctionmark', 'egress', 'epinions', 'hyadapt', 'noop', 'otmetrics', 'resourcestresser', 'seats', 'sibench', 'smallbank', 'tatp', 'tpcc', 'tpch', 'twitter', 'voter', 'wikipedia', 'ycsb' ]
     services:
       postgres: # https://hub.docker.com/_/postgres
         image: postgres:latest

--- a/.run/egress - postgres.run.xml
+++ b/.run/egress - postgres.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="egress - postgres" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="com.oltpbenchmark.DBWorkload" />
+    <module name="benchbase" />
+    <option name="PROGRAM_PARAMETERS" value="-b egress -c config/postgres/sample_egress_config.xml --create=true --load=true --execute=true" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="com.oltpbenchmark.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/config/plugin.xml
+++ b/config/plugin.xml
@@ -17,4 +17,5 @@
     <plugin name="smallbank">com.oltpbenchmark.benchmarks.smallbank.SmallBankBenchmark</plugin>
     <plugin name="hyadapt">com.oltpbenchmark.benchmarks.hyadapt.HYADAPTBenchmark</plugin>
     <plugin name="otmetrics">com.oltpbenchmark.benchmarks.otmetrics.OTMetricsBenchmark</plugin>
+    <plugin name="egress">com.oltpbenchmark.benchmarks.egress.EgressBenchmark</plugin>
 </plugins>

--- a/config/postgres/sample_egress_config.xml
+++ b/config/postgres/sample_egress_config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<parameters>
+
+    <!-- Connection details -->
+    <type>POSTGRES</type>
+    <driver>org.postgresql.Driver</driver>
+    <url>jdbc:postgresql://localhost:5432/benchbase?sslmode=disable&amp;ApplicationName=egress&amp;reWriteBatchedInserts=true</url>
+    <username>admin</username>
+    <password>password</password>
+    <isolation>TRANSACTION_SERIALIZABLE</isolation>
+    <batchsize>128</batchsize>
+
+    <!-- This parameter has no affect on this benchmark-->
+    <!-- There is no data to load -->
+    <scalefactor>1</scalefactor>
+    <egress_tuple_bytes>5</egress_tuple_bytes>
+    <egress_num_tuples>3</egress_num_tuples>
+
+    <!-- The workload -->
+    <terminals>1</terminals>
+    <works>
+        <work>
+            <time>60</time>
+            <rate>1000</rate>
+            <weights>100</weights>
+        </work>
+    </works>
+
+    <!-- Egress Procedures declaration -->
+    <transactiontypes>
+        <transactiontype>
+            <name>Egress</name>
+        </transactiontype>
+    </transactiontypes>
+</parameters>

--- a/src/main/java/com/oltpbenchmark/DBWorkload.java
+++ b/src/main/java/com/oltpbenchmark/DBWorkload.java
@@ -150,6 +150,23 @@ public class DBWorkload {
                 // Nothing to do here !
             }
 
+
+            int egress_tuple_bytes = -1;
+            try {
+                egress_tuple_bytes = xmlConfig.getInt("egress_tuple_bytes");
+                wrkld.setEgressTupleBytes(egress_tuple_bytes);
+            } catch (NoSuchElementException nse) {
+                // Nothing to do here !
+            }
+
+            int egress_num_tuples = -1;
+            try {
+                egress_num_tuples = xmlConfig.getInt("egress_num_tuples");
+                wrkld.setEgressNumTuples(egress_num_tuples);
+            } catch (NoSuchElementException nse) {
+                // Nothing to do here !
+            }
+
             // ----------------------------------------------------------------
             // CREATE BENCHMARK MODULE
             // ----------------------------------------------------------------
@@ -175,6 +192,12 @@ public class DBWorkload {
 
             if (selectivity != -1) {
                 initDebug.put("Selectivity", selectivity);
+            }
+            if (egress_tuple_bytes != -1) {
+                initDebug.put("Egress Tuple Bytes", egress_tuple_bytes);
+            }
+            if (egress_num_tuples != -1) {
+                initDebug.put("Egress Num Tuples", egress_num_tuples);
             }
 
             LOG.info("{}\n\n{}", SINGLE_LINE, StringUtil.formatMaps(initDebug));

--- a/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/main/java/com/oltpbenchmark/WorkloadConfiguration.java
@@ -41,6 +41,8 @@ public class WorkloadConfiguration {
     private int randomSeed = -1;
     private double scaleFactor = 1.0;
     private double selectivity = -1.0;
+    private int egressTupleBytes = 10;
+    private int egressNumTuples = 10;
     private int terminals;
     private int loaderThreads = ThreadUtil.availableProcessors();
     private XMLConfiguration xmlConfig = null;
@@ -152,8 +154,33 @@ public class WorkloadConfiguration {
         phases.add(new Phase(benchmarkName, id, time, warmup, rate, weights, rateLimited, disabled, serial, timed, active_terminals, arrival));
     }
 
+    /**
+     * @return egressTupleBytes length of text field for Egress benchmark.
+     */
+    public int getEgressTupleBytes() {
+        return egressTupleBytes;
+    }
 
+    /**
+     * @param egressTupleBytes length of text field for Egress benchmark.
+     */
+    public void setEgressTupleBytes(int egressTupleBytes) {
+        this.egressTupleBytes = egressTupleBytes;
+    }
 
+    /**
+     * @return egressNumTuples Number of tuples returned for Egress benchmark.
+     */
+    public int getEgressNumTuples() {
+        return egressNumTuples;
+    }
+
+    /**
+     * @param egressNumTuples Number of tuples returned for Egress benchmark.
+     */
+    public void setEgressNumTuples(int egressNumTuples) {
+        this.egressNumTuples = egressNumTuples;
+    }
 
     /**
      * The number of loader threads that the framework is allowed to use.

--- a/src/main/java/com/oltpbenchmark/benchmarks/egress/EgressBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/egress/EgressBenchmark.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.egress;
+
+import com.oltpbenchmark.WorkloadConfiguration;
+import com.oltpbenchmark.api.BenchmarkModule;
+import com.oltpbenchmark.api.Loader;
+import com.oltpbenchmark.api.Worker;
+import com.oltpbenchmark.benchmarks.egress.procedures.Egress;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The Egress Benchmark doesn't have any tables. It uses a UDF to generate tuples to return back to the client.
+ *
+ * @author mbutrovich
+ */
+public class EgressBenchmark extends BenchmarkModule {
+
+    public EgressBenchmark(WorkloadConfiguration workConf) {
+        super(workConf);
+    }
+
+    @Override
+    protected List<Worker<? extends BenchmarkModule>> makeWorkersImpl() {
+        List<Worker<? extends BenchmarkModule>> workers = new ArrayList<>();
+        for (int i = 0; i < workConf.getTerminals(); ++i) {
+            workers.add(new EgressWorker(this, i));
+        }
+        return workers;
+    }
+
+    @Override
+    protected Loader<EgressBenchmark> makeLoaderImpl() {
+        return new EgressLoader(this);
+    }
+
+    @Override
+    protected Package getProcedurePackageImpl() {
+        return Egress.class.getPackage();
+    }
+
+}

--- a/src/main/java/com/oltpbenchmark/benchmarks/egress/EgressLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/egress/EgressLoader.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.egress;
+
+import com.oltpbenchmark.api.Loader;
+import com.oltpbenchmark.api.LoaderThread;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This doesn't load any data!
+ *
+ * @author mbutrovich
+ */
+public class EgressLoader extends Loader<EgressBenchmark> {
+    public EgressLoader(EgressBenchmark benchmark) {
+        super(benchmark);
+    }
+
+    @Override
+    public List<LoaderThread> createLoaderThreads() {
+        return new ArrayList<>();
+    }
+
+}

--- a/src/main/java/com/oltpbenchmark/benchmarks/egress/EgressWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/egress/EgressWorker.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.egress;
+
+import com.oltpbenchmark.api.Procedure.UserAbortException;
+import com.oltpbenchmark.api.TransactionType;
+import com.oltpbenchmark.api.Worker;
+import com.oltpbenchmark.benchmarks.egress.procedures.Egress;
+import com.oltpbenchmark.types.TransactionStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+
+/**
+ * @author mbutrovich
+ */
+public class EgressWorker extends Worker<EgressBenchmark> {
+    private static final Logger LOG = LoggerFactory.getLogger(EgressWorker.class);
+
+    private final Egress procEgress;
+
+    public EgressWorker(EgressBenchmark benchmarkModule, int id) {
+        super(benchmarkModule, id);
+        this.procEgress = this.getProcedure(Egress.class);
+    }
+
+    @Override
+    protected TransactionStatus executeWork(Connection conn, TransactionType nextTrans) throws UserAbortException {
+
+        LOG.debug("Executing {}", this.procEgress);
+        try {
+            this.procEgress.run(conn);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Successfully completed {} execution!", this.procEgress);
+            }
+        } catch (Exception ex) {
+            LOG.error(ex.getMessage(), ex);
+        }
+
+        return (TransactionStatus.SUCCESS);
+    }
+}

--- a/src/main/java/com/oltpbenchmark/benchmarks/egress/procedures/Egress.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/egress/procedures/Egress.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.egress.procedures;
+
+import com.oltpbenchmark.api.Procedure;
+import com.oltpbenchmark.api.SQLStmt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * The actual Egress implementation
+ *
+ * @author mbutrovich
+ */
+public class Egress extends Procedure {
+    private static final Logger LOG = LoggerFactory.getLogger(Egress.class);
+
+
+    // There's no generic query for this benchmark so we leave it as an empty statement. Implement a DBMS-specific DDL
+    // and dialect as needed.
+    public final SQLStmt egressStmt = new SQLStmt(";");
+
+    public void run(Connection conn) {
+        try (PreparedStatement stmt = this.getPreparedStatement(conn, egressStmt)) {
+            stmt.executeQuery();
+            // We don't care about the ResultSet.
+        } catch (Exception ex) {
+            throw new RuntimeException("Egress statement failed.");
+        }
+    }
+
+}

--- a/src/main/resources/benchmarks/egress/ddl-postgres.sql
+++ b/src/main/resources/benchmarks/egress/ddl-postgres.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION egress(text_length int, num_rows int) RETURNS SETOF RECORD AS $$
+DECLARE
+    rec record;
+    temp_string text;
+BEGIN
+    SELECT lpad('', text_length, 'x') INTO temp_string;
+    FOR i IN 1..num_rows LOOP
+        select temp_string into rec;
+        return next rec;
+    END LOOP;
+END $$ language plpgsql;

--- a/src/main/resources/benchmarks/egress/dialect-postgres.xml
+++ b/src/main/resources/benchmarks/egress/dialect-postgres.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<dialects>
+    <dialect type="POSTGRES">
+        <procedure name="Egress">
+            <statement name="egressStmt">
+                SELECT * FROM egress(?, ?) as egress_results(egress_data text);
+            </statement>
+        </procedure>
+    </dialect>
+</dialects>


### PR DESCRIPTION
Not ready for review yet.

This adds a configurable Egress benchmark to return result rows based on two parameters: `egress_tuple_bytes` and `egress_num_tuples`. Since UDF syntax varies by DBMS, this only includes a dialect and ddl file for Postgres. Hopefully folks can add more if this merges.