### PR TITLE
Fix docker entrypoint script so that it handles signals

### DIFF
--- a/docker/benchbase/fullimage/entrypoint.sh
+++ b/docker/benchbase/fullimage/entrypoint.sh
@@ -15,4 +15,4 @@ cd ./profiles/${BENCHBASE_PROFILE}/
 if ! [ -d results/ ] || ! [ -w results/ ]; then
     echo "ERROR: The results directory either doesn't exist or isn't writable." >&2
 fi
-java -jar benchbase.jar $*
+exec java -jar benchbase.jar $*


### PR DESCRIPTION
This is a minor tweak to the docker image entrypoint script so that pid 1 in the container becomes the java process running the benchbase jar.
This is important so that when `docker stop` or `kubectl delete` is executed and a `SIGTERM` is delivered to pid 1 in the container, the bash script is no longer responsible for handling and passing the signal on to the child processes (e.g. java).
Without this, the container runtime needs to wait for the timeout and issue a `SIGKILL` before the java process ends.