### PR TITLE
Fix getDueItems in auctionmark/CloseAuctions

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/procedures/CloseAuctions.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/procedures/CloseAuctions.java
@@ -47,7 +47,7 @@ public class CloseAuctions extends Procedure {
             "SELECT " + AuctionMarkConstants.ITEM_COLUMNS_STR +
                     " FROM " + AuctionMarkConstants.TABLENAME_ITEM + " " +
                     "WHERE (i_start_date BETWEEN ? AND ?) " +
-                    "AND ? " +
+                    "AND i_status = ? " +
                     "ORDER BY i_id ASC " +
                     "LIMIT " + AuctionMarkConstants.CLOSE_AUCTIONS_ITEMS_PER_ROUND
     );


### PR DESCRIPTION
The use site is:

```java
dueItemsStmt.setTimestamp(param++, startTime);
dueItemsStmt.setTimestamp(param++, endTime);
dueItemsStmt.setInt(param++, ItemStatus.OPEN.ordinal());
```

So this def looks like a mistake.