### PR TITLE
YCSB: customizable zipfian constant

### DIFF
--- a/config/cockroachdb/sample_ycsb_config.xml
+++ b/config/cockroachdb/sample_ycsb_config.xml
@@ -17,7 +17,7 @@
     <!-- <fieldSize>8</fieldSize> -->
 
     <!-- Optional: Override the zipfian constant to modify the skew -->
-    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+    <!-- <skewFactor>0.99</skewFactor> -->
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/cockroachdb/sample_ycsb_config.xml
+++ b/config/cockroachdb/sample_ycsb_config.xml
@@ -16,6 +16,9 @@
     <!-- Optional: Override the field size for each column in USERTABLE -->
     <!-- <fieldSize>8</fieldSize> -->
 
+    <!-- Optional: Override the zipfian constant to modify the skew -->
+    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+
     <!-- The workload -->
     <terminals>1</terminals>
     <works>

--- a/config/mariadb/sample_ycsb_config.xml
+++ b/config/mariadb/sample_ycsb_config.xml
@@ -17,7 +17,7 @@
     <!-- <fieldSize>8</fieldSize> -->
 
     <!-- Optional: Override the zipfian constant to modify the skew -->
-    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+    <!-- <skewFactor>0.99</skewFactor> -->
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/mariadb/sample_ycsb_config.xml
+++ b/config/mariadb/sample_ycsb_config.xml
@@ -16,6 +16,9 @@
     <!-- Optional: Override the field size for each column in USERTABLE -->
     <!-- <fieldSize>8</fieldSize> -->
 
+    <!-- Optional: Override the zipfian constant to modify the skew -->
+    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+
     <!-- The workload -->
     <terminals>1</terminals>
     <works>

--- a/config/mysql/sample_ycsb_config.xml
+++ b/config/mysql/sample_ycsb_config.xml
@@ -12,6 +12,9 @@
 
     <!-- Scalefactor in YCSB is *1000 the number of rows in the USERTABLE-->
     <scalefactor>1</scalefactor>
+    
+    <!-- Optional: Override the zipfian constant to modify the skew -->
+    <!-- <zipfianConstant>0.99</zipfianConstant> -->
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/mysql/sample_ycsb_config.xml
+++ b/config/mysql/sample_ycsb_config.xml
@@ -14,7 +14,7 @@
     <scalefactor>1</scalefactor>
     
     <!-- Optional: Override the zipfian constant to modify the skew -->
-    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+    <!-- <skewFactor>0.99</skewFactor> -->
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/noisepage/sample_ycsb_config.xml
+++ b/config/noisepage/sample_ycsb_config.xml
@@ -13,6 +13,9 @@
     <!-- Scalefactor in YCSB is *1000 the number of rows in the USERTABLE-->
     <scalefactor>1</scalefactor>
 
+    <!-- Optional: Override the zipfian constant to modify the skew -->
+    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+
     <!-- The workload -->
     <terminals>1</terminals>
     <works>

--- a/config/noisepage/sample_ycsb_config.xml
+++ b/config/noisepage/sample_ycsb_config.xml
@@ -14,7 +14,7 @@
     <scalefactor>1</scalefactor>
 
     <!-- Optional: Override the zipfian constant to modify the skew -->
-    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+    <!-- <skewFactor>0.99</skewFactor> -->
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/postgres/sample_ycsb_config.xml
+++ b/config/postgres/sample_ycsb_config.xml
@@ -17,7 +17,7 @@
     <!-- <fieldSize>8</fieldSize> -->
 
     <!-- Optional: Override the zipfian constant to modify the skew -->
-    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+    <!-- <skewFactor>0.99</skewFactor> -->
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/postgres/sample_ycsb_config.xml
+++ b/config/postgres/sample_ycsb_config.xml
@@ -16,6 +16,9 @@
     <!-- Optional: Override the field size for each column in USERTABLE -->
     <!-- <fieldSize>8</fieldSize> -->
 
+    <!-- Optional: Override the zipfian constant to modify the skew -->
+    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+
     <!-- The workload -->
     <terminals>1</terminals>
     <works>

--- a/config/spanner/sample_ycsb_config.xml
+++ b/config/spanner/sample_ycsb_config.xml
@@ -15,7 +15,7 @@
     <!-- <fieldSize>8</fieldSize> -->
 
     <!-- Optional: Override the zipfian constant to modify the skew -->
-    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+    <!-- <skewFactor>0.99</skewFactor> -->
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/spanner/sample_ycsb_config.xml
+++ b/config/spanner/sample_ycsb_config.xml
@@ -14,6 +14,9 @@
     <!-- Optional: Override the field size for each column in USERTABLE -->
     <!-- <fieldSize>8</fieldSize> -->
 
+    <!-- Optional: Override the zipfian constant to modify the skew -->
+    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+
     <!-- The workload -->
     <terminals>1</terminals>
     <works>

--- a/config/sqlite/sample_ycsb_config.xml
+++ b/config/sqlite/sample_ycsb_config.xml
@@ -12,7 +12,7 @@
     <scalefactor>1</scalefactor>
 
     <!-- Optional: Override the zipfian constant to modify the skew -->
-    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+    <!-- <skewFactor>0.99</skewFactor> -->
     
     <!-- SQLITE only supports one writer thread -->
     <loaderThreads>1</loaderThreads>

--- a/config/sqlite/sample_ycsb_config.xml
+++ b/config/sqlite/sample_ycsb_config.xml
@@ -10,6 +10,9 @@
 
     <!-- Scalefactor in YCSB is *1000 the number of rows in the USERTABLE-->
     <scalefactor>1</scalefactor>
+
+    <!-- Optional: Override the zipfian constant to modify the skew -->
+    <!-- <zipfianConstant>0.99</zipfianConstant> -->
     
     <!-- SQLITE only supports one writer thread -->
     <loaderThreads>1</loaderThreads>

--- a/config/sqlserver/sample_ycsb_config.xml
+++ b/config/sqlserver/sample_ycsb_config.xml
@@ -17,7 +17,7 @@
     <!-- <fieldSize>8</fieldSize> -->
 
     <!-- Optional: Override the zipfian constant to modify the skew -->
-    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+    <!-- <skewFactor>0.99</skewFactor> -->
 
     <!-- The workload -->
     <terminals>1</terminals>

--- a/config/sqlserver/sample_ycsb_config.xml
+++ b/config/sqlserver/sample_ycsb_config.xml
@@ -16,6 +16,9 @@
     <!-- Optional: Override the field size for each column in USERTABLE -->
     <!-- <fieldSize>8</fieldSize> -->
 
+    <!-- Optional: Override the zipfian constant to modify the skew -->
+    <!-- <zipfianConstant>0.99</zipfianConstant> -->
+
     <!-- The workload -->
     <terminals>1</terminals>
     <works>

--- a/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
@@ -43,6 +43,11 @@ public class YCSBBenchmark extends BenchmarkModule {
      */
     protected final int fieldSize;
 
+    /**
+     * The constant used in the zipfian distribution (to modify the skew)
+     */
+    protected final double zipfianConstant;
+
     public YCSBBenchmark(WorkloadConfiguration workConf) {
         super(workConf);
 
@@ -54,6 +59,15 @@ public class YCSBBenchmark extends BenchmarkModule {
         if (this.fieldSize <= 0) {
             throw new RuntimeException("Invalid YCSB fieldSize '" + this.fieldSize + "'");
         }
+
+        double zipfianConstant = 0.99;
+        if (workConf.getXmlConfig() != null && workConf.getXmlConfig().containsKey("zipfianConstant")) {
+            zipfianConstant = workConf.getXmlConfig().getDouble("zipfianConstant");
+            if (zipfianConstant == 1) {
+                throw new RuntimeException("Invalid YCSB zipfianConstant '" + zipfianConstant + "'");
+            }
+        }
+        this.zipfianConstant = zipfianConstant;
     }
 
     @Override

--- a/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
@@ -60,14 +60,14 @@ public class YCSBBenchmark extends BenchmarkModule {
             throw new RuntimeException("Invalid YCSB fieldSize '" + this.fieldSize + "'");
         }
 
-        double zipfianConstant = 0.99;
-        if (workConf.getXmlConfig() != null && workConf.getXmlConfig().containsKey("zipfianConstant")) {
-            zipfianConstant = workConf.getXmlConfig().getDouble("zipfianConstant");
-            if (zipfianConstant == 1) {
-                throw new RuntimeException("Invalid YCSB zipfianConstant '" + zipfianConstant + "'");
+        double skewFactor = 0.99;
+        if (workConf.getXmlConfig() != null && workConf.getXmlConfig().containsKey("skewFactor")) {
+            skewFactor = workConf.getXmlConfig().getDouble("skewFactor");
+            if (skewFactor == 1) {
+                throw new RuntimeException("Invalid YCSB skewFactor '" + skewFactor + "'");
             }
         }
-        this.zipfianConstant = zipfianConstant;
+        this.zipfianConstant = skewFactor;
     }
 
     @Override

--- a/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
@@ -46,7 +46,7 @@ public class YCSBBenchmark extends BenchmarkModule {
     /**
      * The constant used in the zipfian distribution (to modify the skew)
      */
-    protected final double zipfianConstant;
+    protected final double skewFactor;
 
     public YCSBBenchmark(WorkloadConfiguration workConf) {
         super(workConf);
@@ -67,7 +67,7 @@ public class YCSBBenchmark extends BenchmarkModule {
                 throw new RuntimeException("Invalid YCSB skewFactor '" + skewFactor + "'");
             }
         }
-        this.zipfianConstant = skewFactor;
+        this.skewFactor = skewFactor;
     }
 
     @Override

--- a/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBBenchmark.java
@@ -63,7 +63,7 @@ public class YCSBBenchmark extends BenchmarkModule {
         double skewFactor = 0.99;
         if (workConf.getXmlConfig() != null && workConf.getXmlConfig().containsKey("skewFactor")) {
             skewFactor = workConf.getXmlConfig().getDouble("skewFactor");
-            if (skewFactor == 1) {
+            if (skewFactor <= 0 || skewFactor >= 1) {
                 throw new RuntimeException("Invalid YCSB skewFactor '" + skewFactor + "'");
             }
         }

--- a/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBWorker.java
@@ -58,8 +58,8 @@ class YCSBWorker extends Worker<YCSBBenchmark> {
     public YCSBWorker(YCSBBenchmark benchmarkModule, int id, int init_record_count) {
         super(benchmarkModule, id);
         this.data = new char[benchmarkModule.fieldSize];
-        this.readRecord = new ZipfianGenerator(rng(), init_record_count, benchmarkModule.zipfianConstant);// pool for read keys
-        this.randScan = new ZipfianGenerator(rng(), YCSBConstants.MAX_SCAN, benchmarkModule.zipfianConstant);
+        this.readRecord = new ZipfianGenerator(rng(), init_record_count, benchmarkModule.skewFactor);// pool for read keys
+        this.randScan = new ZipfianGenerator(rng(), YCSBConstants.MAX_SCAN, benchmarkModule.skewFactor);
 
         synchronized (YCSBWorker.class) {
             // We must know where to start inserting

--- a/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBWorker.java
@@ -58,8 +58,8 @@ class YCSBWorker extends Worker<YCSBBenchmark> {
     public YCSBWorker(YCSBBenchmark benchmarkModule, int id, int init_record_count) {
         super(benchmarkModule, id);
         this.data = new char[benchmarkModule.fieldSize];
-        this.readRecord = new ZipfianGenerator(rng(), init_record_count);// pool for read keys
-        this.randScan = new ZipfianGenerator(rng(), YCSBConstants.MAX_SCAN);
+        this.readRecord = new ZipfianGenerator(rng(), init_record_count, benchmarkModule.zipfianConstant);// pool for read keys
+        this.randScan = new ZipfianGenerator(rng(), YCSBConstants.MAX_SCAN, benchmarkModule.zipfianConstant);
 
         synchronized (YCSBWorker.class) {
             // We must know where to start inserting


### PR DESCRIPTION
By adding this line to the config file, the client can modify the zipfian constant used by the zipfian generator in the benchmark: 

`<zipfianConstant>0.99</zipfianConstant>`