### PR TITLE
MariaDB CI Fixups

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -144,7 +144,8 @@ jobs:
           MARIADB_USER: admin
           MARIADB_PASSWORD: password
         options: >-
-          --health-cmd "mysqladmin ping"
+          # Use status instead of ping due to exit code issues: https://jira.mariadb.org/browse/MDEV-31550
+          --health-cmd "mariadb-admin status -p$MARAIADB_ROOT_PASSWORD -uroot"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/docker/benchbase/devcontainer/Dockerfile
+++ b/docker/benchbase/devcontainer/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.source = "https://github.com/cmu-db/benchbase/"
 # Also add a few nice cli tools.
 RUN apt-get update \
     && apt-get -y upgrade \
-    && apt-get -y install --no-install-recommends sudo vim-nox neovim less bash-completion colordiff git jq \
+    && apt-get -y install --no-install-recommends sudo vim-nox neovim less bash-completion colordiff git openssh-client jq \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add a containeruser that allows vscode/codespaces to map the local host user


### PR DESCRIPTION
- Address a change in the MariaDB docker image that replaces `mysqladmin` with `mariadb-admin` that causes our health check command for the CI pipeline service setup to fail.
  - Additionally note a bug in their code that causes a non-zero exit upon auth failures.
- Semi related: ensure that `openssh-client` is included in the devcontainer.
  - Used to be pulled in by `git`, but no longer.