### PR TITLE
Fix CloseAuctions procedure in AuctionMark

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkWorker.java
@@ -444,8 +444,8 @@ public class AuctionMarkWorker extends Worker<AuctionMarkBenchmark> {
             LOG.debug("Executing {}", proc);
         }
         Timestamp[] benchmarkTimes = this.getTimestampParameterArray();
-        Timestamp startTime = profile.getLastCloseAuctionsTime();
-        Timestamp endTime = profile.updateAndGetLastCloseAuctionsTime();
+        Timestamp startTime = Timestamp.from(profile.getLastCloseAuctionsTime().toInstant());
+        Timestamp endTime = Timestamp.from(profile.updateAndGetLastCloseAuctionsTime().toInstant());
 
         List<Object[]> results = proc.run(conn, benchmarkTimes, startTime, endTime);
 

--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/procedures/CloseAuctions.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/procedures/CloseAuctions.java
@@ -116,15 +116,15 @@ public class CloseAuctions extends Procedure {
                     output_rows.clear();
                     while (dueItemsTable.next()) {
                         col = 1;
-                        long itemId = dueItemsTable.getLong(col++);
-                        long sellerId = dueItemsTable.getLong(col++);
+                        String itemId = dueItemsTable.getString(col++);
+                        String sellerId = dueItemsTable.getString(col++);
                         String i_name = dueItemsTable.getString(col++);
                         double currentPrice = dueItemsTable.getDouble(col++);
                         long numBids = dueItemsTable.getLong(col++);
                         Timestamp endDate = dueItemsTable.getTimestamp(col++);
                         ItemStatus itemStatus = ItemStatus.get(dueItemsTable.getLong(col++));
                         Long bidId = null;
-                        Long buyerId = null;
+                        String buyerId = null;
 
                         if (debug) {
                             LOG.debug(String.format("Getting max bid for itemId=%d / sellerId=%d", itemId, sellerId));
@@ -139,15 +139,15 @@ public class CloseAuctions extends Procedure {
                             waiting_ctr++;
 
                             param = 1;
-                            maxBidStmt.setLong(param++, itemId);
-                            maxBidStmt.setLong(param++, sellerId);
+                            maxBidStmt.setString(param++, itemId);
+                            maxBidStmt.setString(param++, sellerId);
                             try (ResultSet maxBidResults = maxBidStmt.executeQuery()) {
                                 adv = maxBidResults.next();
 
 
                                 col = 1;
                                 bidId = maxBidResults.getLong(col++);
-                                buyerId = maxBidResults.getLong(col++);
+                                buyerId = maxBidResults.getString(col++);
                                 try (PreparedStatement preparedStatement = this.getPreparedStatement(conn, insertUserItem, buyerId, itemId, sellerId, currentTime)) {
                                     preparedStatement.executeUpdate();
                                 }

--- a/src/main/resources/benchmarks/auctionmark/dialect-postgres.xml
+++ b/src/main/resources/benchmarks/auctionmark/dialect-postgres.xml
@@ -3,7 +3,7 @@
     <dialect type="POSTGRES">
         <procedure name="CloseAuctions">
             <statement name="updateItemStatus">UPDATE item SET i_status = ?, i_updated = ? WHERE i_id = ? AND i_u_id = ?</statement>
-            <statement name="getDueItems">SELECT i_id, i_u_id, i_name, i_current_price, i_num_bids, i_end_date, i_status FROM item WHERE (i_start_date BETWEEN ? AND ?) AND i_status = 0 ORDER BY i_id ASC LIMIT 100</statement>
+            <statement name="getDueItems">SELECT i_id, i_u_id, i_name, i_current_price, i_num_bids, i_end_date, i_status FROM item WHERE (i_start_date BETWEEN ? AND ?) AND i_status = ? ORDER BY i_id ASC LIMIT 100</statement>
             <statement name="getMaxBid">SELECT imb_ib_id, ib_buyer_id FROM item_max_bid, item_bid WHERE imb_i_id = ? AND imb_u_id = ? AND ib_id = imb_ib_id AND ib_i_id = imb_i_id AND ib_u_id = imb_u_id</statement>
             <statement name="insertUserItem">INSERT INTO useracct_item(ui_u_id, ui_i_id, ui_i_u_id, ui_created) VALUES(?, ?, ?, ?)</statement>
         </procedure>


### PR DESCRIPTION
Fix some bugs in the CloseAuctions procedure of the AuctionMark benchmark:
- Missing status in Postgres's getDueItems query, causing "The column index is out of range" type exceptions;
  ```java
  org.postgresql.util.PSQLException: The column index is out of range: 3, number of columns: 2.
	  at org.postgresql.core.v3.SimpleParameterList.bind(SimpleParameterList.java:70)
	  at org.postgresql.core.v3.SimpleParameterList.setBinaryParameter(SimpleParameterList.java:137)
	  at org.postgresql.jdbc.PgPreparedStatement.bindBytes(PgPreparedStatement.java:1087)
	  at org.postgresql.jdbc.PgPreparedStatement.setInt(PgPreparedStatement.java:322)
	  at com.oltpbenchmark.benchmarks.auctionmark.procedures.CloseAuctions.run(CloseAuctions.java:109)
	  at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkWorker.executeCloseAuctions(AuctionMarkWorker.java:456)
	  at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkWorker.executeWork(AuctionMarkWorker.java:351)
	  at com.oltpbenchmark.api.Worker.doWork(Worker.java:416)
	  at com.oltpbenchmark.api.Worker.run(Worker.java:282)
	  at java.base/java.lang.Thread.run(Thread.java:833)
  ```
- Start and end time in executeCloseAuctions point to the same object, meaning start = end, thus no auctions will be selected to close;
- Code requests longs while the ids are encoded as (non long) strings, resulting in casting errors:
  ```java
  org.postgresql.util.PSQLException: Bad value for type long : 000000000100000000070000000001
	  at org.postgresql.jdbc.PgResultSet.toLong(PgResultSet.java:3323)
	  at org.postgresql.jdbc.PgResultSet.getLong(PgResultSet.java:2540)
	  at com.oltpbenchmark.benchmarks.auctionmark.procedures.CloseAuctions.run(CloseAuctions.java:127)
	  at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkWorker.executeCloseAuctions(AuctionMarkWorker.java:456)
	  at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkWorker.executeWork(AuctionMarkWorker.java:351)
	  at com.oltpbenchmark.api.Worker.doWork(Worker.java:416)
	  at com.oltpbenchmark.api.Worker.run(Worker.java:282)
	  at java.base/java.lang.Thread.run(Thread.java:833)
  ```