### PR TITLE
Fix concurrent modification error in AuctionMark

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkProfile.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkProfile.java
@@ -746,8 +746,8 @@ public class AuctionMarkProfile {
                 continue;
             }
 
-            for (ItemInfo itemInfo : items) {
-                this.addItemToProperQueue(itemInfo, currentTime);
+            for (Iterator<ItemInfo> it = items.iterator(); it.hasNext();) {
+                this.addItemToProperQueue(it.next(), currentTime, it);
             }
         }
 
@@ -767,10 +767,10 @@ public class AuctionMarkProfile {
         Timestamp baseTime = (is_loader ? this.getLoaderStartTime() : this.getCurrentTime());
 
 
-        return addItemToProperQueue(itemInfo, baseTime);
+        return addItemToProperQueue(itemInfo, baseTime, null);
     }
 
-    private ItemStatus addItemToProperQueue(ItemInfo itemInfo, Timestamp baseTime) {
+    private ItemStatus addItemToProperQueue(ItemInfo itemInfo, Timestamp baseTime, Iterator<ItemInfo> currentQueueIterator) {
         // Always check whether we even want it for this client
         // The loader's profile and the cache profile will always have a negative client_id,
         // which means that we always want to keep it
@@ -799,30 +799,25 @@ public class AuctionMarkProfile {
 
 
         if (!new_status.equals(existingStatus)) {
+            // Remove the item from the current queue
+            if (currentQueueIterator != null) {
+                currentQueueIterator.remove();
+            }
+
             switch (new_status) {
                 case OPEN:
                     this.addItem(this.items_available, itemInfo);
                     break;
                 case ENDING_SOON:
-                    this.items_available.remove(itemInfo);
                     this.addItem(this.items_endingSoon, itemInfo);
                     break;
                 case WAITING_FOR_PURCHASE:
-                    (existingStatus == ItemStatus.OPEN ? this.items_available : this.items_endingSoon).remove(itemInfo);
                     this.addItem(this.items_waitingForPurchase, itemInfo);
                     break;
                 case CLOSED:
-                    if (existingStatus == ItemStatus.OPEN) {
-                        this.items_available.remove(itemInfo);
-                    } else if (existingStatus == ItemStatus.ENDING_SOON) {
-                        this.items_endingSoon.remove(itemInfo);
-                    } else {
-                        this.items_waitingForPurchase.remove(itemInfo);
-                    }
                     this.addItem(this.items_completed, itemInfo);
                     break;
                 default:
-
             }
             itemInfo.setStatus(new_status);
         }


### PR DESCRIPTION
In the `updateItemQueues` function, the code iterates each item queue and calls the `addItemToProperQueue` for each item. One step this function does is remove the item from the original list, if the new status is different from the old one.
This, however, triggers a `ConcurrentModificationException` exception since we are iterating and removing concurrently from the linked list:

```java
java.util.ConcurrentModificationException
	at java.base/java.util.LinkedList$ListItr.checkForComodification(LinkedList.java:970)
	at java.base/java.util.LinkedList$ListItr.next(LinkedList.java:892)
	at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkProfile.updateItemQueues(AuctionMarkProfile.java:749)
	at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkWorker.executeCloseAuctions(AuctionMarkWorker.java:454)
	at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkWorker.executeWork(AuctionMarkWorker.java:350)
	at com.oltpbenchmark.api.Worker.doWork(Worker.java:416)
	at com.oltpbenchmark.api.Worker.run(Worker.java:282)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

The proposed solution passes a reference to the iterator in the `updateItemQueues` function, so the `addItemToProperQueue` can safely remove the element using `iterator.remove()`. This also means that the code in the `addItemToProperQueue` function does not need to iterate over the entire list again by calling `remove`, improving performance. The other functions that call `updateItemQueues` seem to be always new items, so we can set the iterator as null as they don't need to remove from an existing queue.

