### PR TITLE
Fix item id assignment in AuctionMark

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkProfile.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkProfile.java
@@ -698,9 +698,9 @@ public class AuctionMarkProfile {
         Integer cnt = this.seller_item_cnt.get(seller_id);
         if (cnt == null || cnt == 0) {
             cnt = seller_id.getItemCount();
-            //this.seller_item_cnt.put(seller_id, cnt);
+            this.seller_item_cnt.put(seller_id, cnt);
         }
-        this.seller_item_cnt.put(seller_id, cnt);
+        this.seller_item_cnt.put(seller_id, 1);
         return (new ItemId(seller_id, cnt));
     }
 


### PR DESCRIPTION
After retrieving the next item id, the `getNextItemId` function increments the counter with itself, effectively doubling the amount each time. This results in an exponential growth, causing the integer to overflow in just a few iterations, later resulting in the following exception:

```java
java.lang.NumberFormatException: For input string: "0-41943040"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:668)
	at java.base/java.lang.Integer.parseInt(Integer.java:786)
	at com.oltpbenchmark.benchmarks.auctionmark.util.ItemId.decode(ItemId.java:62)
	at com.oltpbenchmark.benchmarks.auctionmark.util.ItemId.<init>(ItemId.java:50)
	at com.oltpbenchmark.benchmarks.auctionmark.util.AuctionMarkUtil.getUniqueElementId(AuctionMarkUtil.java:39)
	at com.oltpbenchmark.benchmarks.auctionmark.procedures.NewItem.run(NewItem.java:203)
	at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkWorker.executeNewItem(AuctionMarkWorker.java:764)
	at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkWorker.executeWork(AuctionMarkWorker.java:371)
	at com.oltpbenchmark.api.Worker.doWork(Worker.java:416)
	at com.oltpbenchmark.api.Worker.run(Worker.java:282)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

This also solves the `executeNewItem - a duplicate item existed` type warnings in the log, as the counter now starts with the correct value.

It fixes #335.