### PR TITLE
Fix Port Binding Issue During Testing

### DIFF
--- a/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
@@ -99,18 +99,33 @@ public abstract class AbstractTestCase<T extends BenchmarkModule> {
         HsqlProperties props = new HsqlProperties();
         //props.setProperty("server.remote_open", true);
 
-        int port = portCounter.incrementAndGet();
-
-        LOG.info("starting HSQLDB server for test [{}] on port [{}]", name.getMethodName(), port);
-
         server = new Server();
         server.setProperties(props);
         server.setDatabasePath(0, "mem:benchbase;sql.syntax_mys=true");
         server.setDatabaseName(0, "benchbase");
         server.setAddress("localhost");
-        server.setPort(port);
         server.setSilent(true);
         server.setLogWriter(null);
+
+        int port = -1;
+        boolean portFound = false;
+
+        for (int i = 0; i < MAX_TRIES; i++) {
+            port = portCounter.incrementAndGet();
+            try (ServerSocket testSocket = new ServerSocket(port)) {
+                portFound = true;
+                break;
+            } catch (BindException e) {
+                continue;
+            }   
+        }
+
+        if (!portFound) {
+            throw new RuntimeException("Unable to find an available port after " + MAX_TRIES + " tries.");
+        }
+
+        LOG.info("starting HSQLDB server for test [{}] on port [{}]", name.getMethodName(), port);
+        server.setPort(port);
         server.start();
 
         this.workConf = new WorkloadConfiguration();

--- a/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
@@ -39,6 +39,8 @@ import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.net.ServerSocket;
+import java.net.BindException;
 
 public abstract class AbstractTestCase<T extends BenchmarkModule> {
 
@@ -69,6 +71,7 @@ public abstract class AbstractTestCase<T extends BenchmarkModule> {
     protected final String ddlOverridePath;
 
     private static final AtomicInteger portCounter = new AtomicInteger(9001);
+    private static final int MAX_TRIES = 10;
 
 
     public AbstractTestCase(boolean createDatabase, boolean loadDatabase) {

--- a/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
@@ -178,6 +178,7 @@ public abstract class AbstractTestCase<T extends BenchmarkModule> {
                 return port;
             } catch (BindException e) {
                 // This port is already in use. Continue to next port.
+                LOG.warn("Port {} is already in use. Trying next port.", port);
             }
         }
     }

--- a/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
@@ -113,7 +113,7 @@ public abstract class AbstractTestCase<T extends BenchmarkModule> {
         server.setAddress("localhost");
         server.setPort(port);
         server.setSilent(true);
-        server.setLogWriter(null); 
+        server.setLogWriter(null);
         server.start();
 
         this.workConf = new WorkloadConfiguration();

--- a/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestCase.java
@@ -105,7 +105,7 @@ public abstract class AbstractTestCase<T extends BenchmarkModule> {
         int port = findAvailablePort();
 
         LOG.info("starting HSQLDB server for test [{}] on port [{}]", name.getMethodName(), port);
-        
+
         server = new Server();
         server.setProperties(props);
         server.setDatabasePath(0, "mem:benchbase;sql.syntax_mys=true");
@@ -113,7 +113,7 @@ public abstract class AbstractTestCase<T extends BenchmarkModule> {
         server.setAddress("localhost");
         server.setPort(port);
         server.setSilent(true);
-        server.setLogWriter(null);        
+        server.setLogWriter(null); 
         server.start();
 
         this.workConf = new WorkloadConfiguration();


### PR DESCRIPTION
This PR addresses the issue where tests would fail if the designated port was already in use. 
```
[INFO ] 2023-10-25 07:18:47,185 [main]  com.oltpbenchmark.benchmarks.resourcestresser.TestResourceStresserBenchmark setUp - starting HSQLDB server for test [testGetTransactionType] on port [9099]
[Server@191774d6]: [Thread[HSQLDB Server @191774d6,5,main]]: run()/openServerSocket(): 
java.net.BindException: Address already in use
```
Changes:

- Modified the `setUp` method in `TestResourceStresserBenchmark` class.
- Added logic to try different ports using `ServerSocket` to find an available port.
- ~~The system will attempt up to `MAX_TRIES` to find an open port before throwing an exception.~~
- The the system will make a thorough effort in finding an available port.
