### PR TITLE
Splitting otmetrics fix from #379

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,4 @@ We also acknowledge contributions from the following collaborators:
 
 + [Florian Funke](http://www3.in.tum.de/~funkef/)
 + [Michael Seibold](http://www3.in.tum.de/~seibold/)
++ [Oracle](https://github.com/oracle) (Copyright (c) 2023, Oracle and/or its affiliates.)

--- a/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/procedures/GetSessionRange.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/otmetrics/procedures/GetSessionRange.java
@@ -70,6 +70,8 @@ public class GetSessionRange extends Procedure {
                 finalResults.add(arr);
             }
         }
+	    stmt.close();
+
         return (finalResults);
     }
 


### PR DESCRIPTION
Splitting otmetrics fix from PR #379.

Fix procedure `GetSessionRange` in otmetrics, which did not explicitly close SQL statement from `getPreparedStatement`.