### PR TITLE
After load functionality with test

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,4 @@ We also acknowledge contributions from the following collaborators:
 
 + [Florian Funke](http://www3.in.tum.de/~funkef/)
 + [Michael Seibold](http://www3.in.tum.de/~seibold/)
++ [Oracle](https://github.com/oracle) (Copyright (c) 2023, Oracle and/or its affiliates.)

--- a/src/main/java/com/oltpbenchmark/DBWorkload.java
+++ b/src/main/java/com/oltpbenchmark/DBWorkload.java
@@ -214,6 +214,11 @@ public class DBWorkload {
                     postExecutionWait = xmlConfig.getLong(key + "/postExecutionWait");
                 }
 
+                // After load
+                if (xmlConfig.containsKey("afterload")) {
+                    bench.setAfterLoadScriptPath(xmlConfig.getString("afterload"));
+                }
+
                 TransactionType tmpType = bench.initTransactionType(txnName, txnId + txnIdOffset, preExecutionWait, postExecutionWait);
 
                 // Keep a reference for filtering
@@ -626,7 +631,7 @@ public class DBWorkload {
         bench.createDatabase();
     }
 
-    private static void runLoader(BenchmarkModule bench) throws SQLException, InterruptedException {
+    private static void runLoader(BenchmarkModule bench) throws IOException, SQLException, InterruptedException {
         LOG.debug(String.format("Loading %s Database", bench));
         bench.loadDatabase();
     }

--- a/src/test/java/com/oltpbenchmark/api/AbstractTestLoader.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestLoader.java
@@ -67,6 +67,15 @@ public abstract class AbstractTestLoader<T extends BenchmarkModule> extends Abst
 
         this.benchmark.loadDatabase();
 
+        // A table called extra is added with after-load, with one entry zero
+        try (PreparedStatement stmt = conn.prepareStatement("SELECT * FROM extra"); ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                assertEquals("Table 'extra' from /after-load.sql has value different than 0", rs.getInt(1), 0);
+            }
+        } catch (Exception e) {
+            fail("Table 'extra' from /after-load.sql was not created");
+        }
+
         validateLoad();
 
     }
@@ -98,16 +107,6 @@ public abstract class AbstractTestLoader<T extends BenchmarkModule> extends Abst
             }
         }
 
-        // A table called extra is added with after-load, with one
-        if (this.benchmark.getAfterLoadScriptPath() != null) {
-            try (PreparedStatement stmt = conn.prepareStatement("SELECT * FROM extra"); ResultSet rs = stmt.executeQuery()) {
-                while (rs.next()) {
-                    assertEquals("Table 'extra' from /after-load.sql has value different than 0", rs.getInt(1), 0);
-                }
-            } catch (Exception e) {
-                fail("Table 'extra' from /after-load.sql was not initialized");
-            }
-        }
 
         LOG.debug("=== TABLE SIZES ===\n" + tableSizes);
         assertFalse("Unable to compute the tables size for " + benchmark.getBenchmarkName().toUpperCase(), tableSizes.isEmpty());

--- a/src/test/java/com/oltpbenchmark/api/AbstractTestLoader.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestLoader.java
@@ -77,7 +77,6 @@ public abstract class AbstractTestLoader<T extends BenchmarkModule> extends Abst
         }
 
         validateLoad();
-
     }
 
     private void validateLoad() throws SQLException {

--- a/src/test/java/com/oltpbenchmark/api/AbstractTestLoader.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestLoader.java
@@ -106,7 +106,6 @@ public abstract class AbstractTestLoader<T extends BenchmarkModule> extends Abst
             }
         }
 
-
         LOG.debug("=== TABLE SIZES ===\n" + tableSizes);
         assertFalse("Unable to compute the tables size for " + benchmark.getBenchmarkName().toUpperCase(), tableSizes.isEmpty());
 

--- a/src/test/java/com/oltpbenchmark/api/AbstractTestLoader.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestLoader.java
@@ -70,10 +70,10 @@ public abstract class AbstractTestLoader<T extends BenchmarkModule> extends Abst
         // A table called extra is added with after-load, with one entry zero
         try (PreparedStatement stmt = conn.prepareStatement("SELECT * FROM extra"); ResultSet rs = stmt.executeQuery()) {
             while (rs.next()) {
-                assertEquals("Table 'extra' from /after-load.sql has value different than 0", rs.getInt(1), 0);
+                assertEquals("Table 'extra' from after-load.sql has value different than 0", rs.getInt(1), 0);
             }
         } catch (Exception e) {
-            fail("Table 'extra' from /after-load.sql was not created");
+            fail("Table 'extra' from after-load.sql was not created");
         }
 
         validateLoad();

--- a/src/test/java/com/oltpbenchmark/api/AbstractTestLoader.java
+++ b/src/test/java/com/oltpbenchmark/api/AbstractTestLoader.java
@@ -17,10 +17,6 @@
 
 package com.oltpbenchmark.api;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import com.oltpbenchmark.catalog.Table;
 import com.oltpbenchmark.util.Histogram;
 import com.oltpbenchmark.util.SQLUtil;
@@ -28,10 +24,14 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 public abstract class AbstractTestLoader<T extends BenchmarkModule> extends AbstractTestCase<T> {
 
@@ -51,6 +51,19 @@ public abstract class AbstractTestLoader<T extends BenchmarkModule> extends Abst
      */
     @Test
     public void testLoad() throws Exception {
+
+        this.benchmark.loadDatabase();
+
+        validateLoad();
+
+    }
+
+    /**
+     * testLoad with after load script
+     */
+    @Test
+    public void testLoadWithAfterLoad() throws Exception {
+        this.benchmark.setAfterLoadScriptPath("/after-load.sql");
 
         this.benchmark.loadDatabase();
 
@@ -82,6 +95,17 @@ public abstract class AbstractTestLoader<T extends BenchmarkModule> extends Abst
                 int count = result.getInt(1);
                 LOG.debug(sql + " => " + count);
                 tableSizes.put(tableName, count);
+            }
+        }
+
+        // A table called extra is added with after-load, with one
+        if (this.benchmark.getAfterLoadScriptPath() != null) {
+            try (PreparedStatement stmt = conn.prepareStatement("SELECT * FROM extra"); ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    assertEquals("Table 'extra' from /after-load.sql has value different than 0", rs.getInt(1), 0);
+                }
+            } catch (Exception e) {
+                fail("Table 'extra' from /after-load.sql was not initialized");
             }
         }
 

--- a/src/test/resources/after-load.sql
+++ b/src/test/resources/after-load.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS extra CASCADE;
+
+CREATE TABLE extra (
+    extra_pk int NOT NULL,
+    PRIMARY KEY (extra_pk)
+);
+
+INSERT INTO extra VALUES (0);


### PR DESCRIPTION
Splitting after load functionality needed for Oracle config from PR https://github.com/cmu-db/benchbase/pull/379.

Add an after load option for benchmark configs.

Benchmark configs can add an afterload tag specifying a path to an SQL file in resources. This file will be executed after loading database. 

Tested in `AbstractTestLoad.testLoadWithAfterLoad()`