### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Enforce and apply Google Java Style formatting (#416)
+56e3191bf8df94dcdf226ae814a9aa2c08b931b9


### PR DESCRIPTION
Follow-on work to #416, this file uses a [`.git-blame-ignore-revs` file](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) to ignore revs that cause major reformatting changes in git blame view.