### PR TITLE
Fix: Changed INSERT statements of templated benchmarks

### DIFF
--- a/config/cockroachdb/sample_templated_config.xml
+++ b/config/cockroachdb/sample_templated_config.xml
@@ -24,7 +24,7 @@
         <work>
             <time>10</time>
             <rate>100</rate>
-            <weights>20,20,10,10,10,10,10<!-- FIXME: ,10 --></weights>
+            <weights>20,20,10,10,10,10,10,10</weights>
         </work>
     </works>
 
@@ -51,10 +51,8 @@
         <transactiontype>
             <name>DeleteItem</name>
         </transactiontype>
-        <!-- FIXME:
         <transactiontype>
             <name>InsertItem</name>
         </transactiontype>
-        -->
     </transactiontypes>
 </parameters>

--- a/config/mariadb/sample_templated_config.xml
+++ b/config/mariadb/sample_templated_config.xml
@@ -25,7 +25,7 @@
         <work>
             <time>10</time>
             <rate>100</rate>
-            <weights>20,20,10,10,10,10,10<!-- FIXME: ,10 --></weights>
+            <weights>20,20,10,10,10,10,10,10</weights>
         </work>
     </works>
 
@@ -52,10 +52,8 @@
         <transactiontype>
             <name>DeleteItem</name>
         </transactiontype>
-        <!-- FIXME:
         <transactiontype>
             <name>InsertItem</name>
         </transactiontype>
-        -->
     </transactiontypes>
 </parameters>

--- a/config/mysql/sample_templated_config.xml
+++ b/config/mysql/sample_templated_config.xml
@@ -25,7 +25,7 @@
         <work>
             <time>10</time>
             <rate>100</rate>
-            <weights>20,20,10,10,10,10,10<!-- FIXME: ,10 --></weights>
+            <weights>20,20,10,10,10,10,10,10</weights>
         </work>
     </works>
 
@@ -52,10 +52,8 @@
         <transactiontype>
             <name>DeleteItem</name>
         </transactiontype>
-        <!-- FIXME:
         <transactiontype>
             <name>InsertItem</name>
         </transactiontype>
-        -->
     </transactiontypes>
 </parameters>

--- a/config/oracle/sample_templated_config.xml
+++ b/config/oracle/sample_templated_config.xml
@@ -25,7 +25,7 @@
         <work>
             <time>10</time>
             <rate>100</rate>
-            <weights>20,20,10,10,10,10,10<!-- FIXME: ,10 --></weights>
+            <weights>20,20,10,10,10,10,10,10</weights>
         </work>
     </works>
 
@@ -52,10 +52,8 @@
         <transactiontype>
             <name>DeleteItem</name>
         </transactiontype>
-        <!-- FIXME:
         <transactiontype>
             <name>InsertItem</name>
         </transactiontype>
-        -->
     </transactiontypes>
 </parameters>

--- a/config/postgres/sample_templated_config.xml
+++ b/config/postgres/sample_templated_config.xml
@@ -25,7 +25,7 @@
         <work>
             <time>10</time>
             <rate>100</rate>
-            <weights>20,20,10,10,10,10,10<!-- FIXME: ,10 --></weights>
+            <weights>20,20,10,10,10,10,10,10</weights>
         </work>
     </works>
 
@@ -52,10 +52,8 @@
         <transactiontype>
             <name>DeleteItem</name>
         </transactiontype>
-        <!-- FIXME:
         <transactiontype>
             <name>InsertItem</name>
         </transactiontype>
-        -->
     </transactiontypes>
 </parameters>

--- a/config/sqlite/sample_templated_config.xml
+++ b/config/sqlite/sample_templated_config.xml
@@ -22,7 +22,7 @@
         <work>
             <time>10</time>
             <rate>100</rate>
-            <weights>20,20,10,10,10,10,10<!-- FIXME: ,10 --></weights>
+            <weights>20,20,10,10,10,10,10,10</weights>
         </work>
     </works>
 
@@ -49,10 +49,8 @@
         <transactiontype>
             <name>DeleteItem</name>
         </transactiontype>
-        <!-- FIXME:
         <transactiontype>
             <name>InsertItem</name>
         </transactiontype>
-        -->
     </transactiontypes>
 </parameters>

--- a/config/sqlserver/sample_templated_config.xml
+++ b/config/sqlserver/sample_templated_config.xml
@@ -25,7 +25,7 @@
         <work>
             <time>10</time>
             <rate>100</rate>
-            <weights>20,20,10,10,10,10,10<!-- FIXME: ,10 --></weights>
+            <weights>20,20,10,10,10,10,10,10</weights>
         </work>
     </works>
 
@@ -52,10 +52,8 @@
         <transactiontype>
             <name>DeleteItem</name>
         </transactiontype>
-        <!-- FIXME:
         <transactiontype>
             <name>InsertItem</name>
         </transactiontype>
-        -->
     </transactiontypes>
 </parameters>

--- a/data/templated/example.xml
+++ b/data/templated/example.xml
@@ -79,23 +79,27 @@
          <value>255.0</value>
       </values>
    </template>
-   <!-- FIXME: This results in primary key failures due to duplicate keys.
    <template name="InsertItem">
-      <query><![CDATA[INSERT INTO item VALUES(?,?,?,?,?)]]></query>
+      <query><![CDATA[INSERT INTO history VALUES(?,?,?,?,?,?,?,?)]]></query>
       <types>
          <type>INTEGER</type>
-         <type>VARCHAR</type>
+         <type>INTEGER</type>
+         <type>INTEGER</type>
+         <type>INTEGER</type>
+         <type>INTEGER</type>
+         <type>TIMESTAMP</type>
          <type>FLOAT</type>
          <type>VARCHAR</type>
-         <type>INTEGER</type>
       </types>
       <values>
-         <value>100001</value>
-         <value>Testname</value>
-         <value>255.1</value>
-         <value>Testdata</value>
          <value>1</value>
+         <value>1</value>
+         <value>1</value>
+         <value>1</value>
+         <value>1</value>
+         <value>2022-10-10 11:30:30</value>
+         <value>1.0</value>
+         <value>Test</value>
       </values>
    </template>
-   -->
 </templates>


### PR DESCRIPTION
INSERT query was not working due to duplicate primary keys

Simple solutions on the query did not work for all systems
(For example _INSERT IGNORE, INSERT -- IF NOT EXISTS_).

For now I changed the table of the insert to one that does not have a primary key.

This PR tries to solve #428 