### PR TITLE
Fix scan length distribution for YCSB

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/ycsb/YCSBWorker.java
@@ -23,6 +23,7 @@ import com.oltpbenchmark.api.TransactionType;
 import com.oltpbenchmark.api.Worker;
 import com.oltpbenchmark.benchmarks.ycsb.procedures.*;
 import com.oltpbenchmark.distributions.CounterGenerator;
+import com.oltpbenchmark.distributions.UniformGenerator;
 import com.oltpbenchmark.distributions.ZipfianGenerator;
 import com.oltpbenchmark.types.TransactionStatus;
 import com.oltpbenchmark.util.TextGenerator;
@@ -39,7 +40,7 @@ class YCSBWorker extends Worker<YCSBBenchmark> {
 
   private final ZipfianGenerator readRecord;
   private static CounterGenerator insertRecord;
-  private final ZipfianGenerator randScan;
+  private final UniformGenerator randScan;
 
   private final char[] data;
   private final String[] params = new String[YCSBConstants.NUM_FIELDS];
@@ -58,7 +59,7 @@ class YCSBWorker extends Worker<YCSBBenchmark> {
     this.readRecord =
         new ZipfianGenerator(
             rng(), init_record_count, benchmarkModule.skewFactor); // pool for read keys
-    this.randScan = new ZipfianGenerator(rng(), YCSBConstants.MAX_SCAN, benchmarkModule.skewFactor);
+    this.randScan = new UniformGenerator(1, YCSBConstants.MAX_SCAN);
 
     synchronized (YCSBWorker.class) {
       // We must know where to start inserting
@@ -100,41 +101,35 @@ class YCSBWorker extends Worker<YCSBBenchmark> {
   }
 
   private void updateRecord(Connection conn) throws SQLException {
-
     int keyname = readRecord.nextInt();
     this.buildParameters();
     this.procUpdateRecord.run(conn, keyname, this.params);
   }
 
   private void scanRecord(Connection conn) throws SQLException {
-
     int keyname = readRecord.nextInt();
     int count = randScan.nextInt();
     this.procScanRecord.run(conn, keyname, count, new ArrayList<>());
   }
 
   private void readRecord(Connection conn) throws SQLException {
-
     int keyname = readRecord.nextInt();
     this.procReadRecord.run(conn, keyname, this.results);
   }
 
   private void readModifyWriteRecord(Connection conn) throws SQLException {
-
     int keyname = readRecord.nextInt();
     this.buildParameters();
     this.procReadModifyWriteRecord.run(conn, keyname, this.params, this.results);
   }
 
   private void insertRecord(Connection conn) throws SQLException {
-
     int keyname = insertRecord.nextInt();
     this.buildParameters();
     this.procInsertRecord.run(conn, keyname, this.params);
   }
 
   private void deleteRecord(Connection conn) throws SQLException {
-
     int keyname = readRecord.nextInt();
     this.procDeleteRecord.run(conn, keyname);
   }

--- a/src/main/java/com/oltpbenchmark/distributions/UniformGenerator.java
+++ b/src/main/java/com/oltpbenchmark/distributions/UniformGenerator.java
@@ -1,0 +1,38 @@
+package com.oltpbenchmark.distributions;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class UniformGenerator extends IntegerGenerator {
+  int min, max;
+
+  /**
+   * Create a uniformly distributed random number generator for items.
+   *
+   * @param items Number of items.
+   */
+  public UniformGenerator(int items) {
+    this(0, items - 1);
+  }
+
+  /**
+   * Create a uniformly distributed random number generator for items between min and max
+   * (inclusive).
+   *
+   * @param min Smallest integer to generate in the sequence.
+   * @param max Largest integer to generate in the sequence.
+   */
+  public UniformGenerator(int min, int max) {
+    this.min = min;
+    this.max = max;
+  }
+
+  @Override
+  public int nextInt() {
+    return ThreadLocalRandom.current().nextInt(this.min, this.max + 1);
+  }
+
+  @Override
+  public double mean() {
+    return (this.max + this.min) / 2.0;
+  }
+}

--- a/src/main/java/com/oltpbenchmark/distributions/UniformGenerator.java
+++ b/src/main/java/com/oltpbenchmark/distributions/UniformGenerator.java
@@ -3,7 +3,8 @@ package com.oltpbenchmark.distributions;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class UniformGenerator extends IntegerGenerator {
-  int min, max;
+  int min;
+  int max;
 
   /**
    * Create a uniformly distributed random number generator for items.


### PR DESCRIPTION
## TL;DR

This patch changes the distribution of scan lengths in YCSB from a Zipfian distribution to a uniform distribution.

## Background

The default distribution of scan lengths in YCSB Workload E is uniform [^1] [^2] [^3]. The current implementation uses Zipfian distribution with a specified skew factor, which should be avoided for fair evaluation of scan performance.

<img width="1458" alt="Screenshot 2024-02-14 at 15 48 10" src="https://github.com/cmu-db/benchbase/assets/1114146/f8761826-96b7-403b-87a4-4bafad9e6c4f">

[^1]: https://github.com/brianfrankcooper/YCSB/blob/ce3eb9/workloads/workloade#L44
[^2]: https://github.com/brianfrankcooper/YCSB/blob/ce3eb9/core/src/main/java/site/ycsb/workloads/CoreWorkload.java#L536
[^3]: https://doi.org/10.1145/1807128.1807152