### PR TITLE
Let --dialects-export output sql in log

### DIFF
--- a/src/main/java/com/oltpbenchmark/DBWorkload.java
+++ b/src/main/java/com/oltpbenchmark/DBWorkload.java
@@ -449,7 +449,7 @@ public class DBWorkload {
                 .export(
                     bench.getWorkloadConfiguration().getDatabaseType(),
                     bench.getProcedures().values());
-        LOG.debug(xml);
+        LOG.info(xml);
         System.exit(0);
       }
       throw new RuntimeException("No StatementDialects is available for " + bench);


### PR DESCRIPTION
Respect `--dialects-export` option, when enabled, it should output SQL in log.

Close #252 

### Example

```xml
mvn compile exec:java -P postgres -Dexec.args="--dialects-export true -b twitter -c twitter_config.xml"

...
<dialects>
    <dialect type="POSTGRES">
        <procedure name="GetFollowers">
            <statement name="getFollowerNames">SELECT uid, name FROM "user_profiles" WHERE uid IN (??)</statement>
            <statement name="getFollowers">SELECT f2 FROM "followers" WHERE f1 = ? LIMIT 20</statement>
        </procedure>
        <procedure name="GetTweet">
            <statement name="getTweet">SELECT * FROM "tweets" WHERE id = ?</statement>
        </procedure>
        <procedure name="GetTweetsFromFollowing">
            <statement name="getTweets">SELECT * FROM "tweets" WHERE uid IN (??)</statement>
            <statement name="getFollowing">SELECT f2 FROM "follows" WHERE f1 = ? LIMIT 20</statement>
        </procedure>
        <procedure name="GetUserTweets">
            <statement name="getTweets">SELECT * FROM "tweets" WHERE uid = ? LIMIT 10</statement>
        </procedure>
        <procedure name="InsertTweet">
            <statement name="insertTweet">INSERT INTO "added_tweets" VALUES (default, ?, ?, ?)</statement>
        </procedure>
    </dialect>
</dialects>
```