### PR TITLE
Fix mvn exec:java ClassNotFoundException

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Compile with Maven
         run: mvn -B compile test-compile --file pom.xml
 
+      - name: Test exec plugin
+        run: |
+          mvn exec:java -P sqlite -Dexec.args="-b noop -c config/sqlite/sample_noop_config.xml --create=true --load=true --execute=true"
+
       - name: Test with Maven
         run: mvn -B test --file pom.xml
 

--- a/src/main/java/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/main/java/com/oltpbenchmark/api/BenchmarkModule.java
@@ -62,7 +62,7 @@ public abstract class BenchmarkModule {
     this.workConf = workConf;
     this.dialects = new StatementDialects(workConf);
     // setClassLoader();
-    this.classLoader = ClassLoader.getSystemClassLoader();
+    this.classLoader = Thread.currentThread().getContextClassLoader();
   }
 
   /**
@@ -70,7 +70,7 @@ public abstract class BenchmarkModule {
    * implementation.
    */
   protected void setClassLoader() {
-    this.classLoader = ClassLoader.getSystemClassLoader();
+    this.classLoader = Thread.currentThread().getContextClassLoader();
   }
 
   // --------------------------------------------------------------------------

--- a/src/main/java/com/oltpbenchmark/util/ClassUtil.java
+++ b/src/main/java/com/oltpbenchmark/util/ClassUtil.java
@@ -184,7 +184,7 @@ public abstract class ClassUtil {
    * @return
    */
   public static Class<?> getClass(String class_name) {
-    return getClass(ClassLoader.getSystemClassLoader(), class_name);
+    return getClass(Thread.currentThread().getContextClassLoader(), class_name);
   }
 
   /**


### PR DESCRIPTION
This was reported by #493.

Running benchmarks without packaging first fails like so:

```
mvn clean compile exec:java -P postgres -Dexec.args="-b tpcc -c config/postgres/sample_tpcc_config.xml --create=true --load=true --execute=true"

java.lang.RuntimeException: Failed to retrieve class for com.oltpbenchmark.benchmarks.tpcc.TPCCBenchmark
    at com.oltpbenchmark.util.ClassUtil.getClass (ClassUtil.java:200)
    at com.oltpbenchmark.util.ClassUtil.getClass (ClassUtil.java:187)
    at com.oltpbenchmark.util.ClassUtil.newInstance (ClassUtil.java:112)
    at com.oltpbenchmark.DBWorkload.main (DBWorkload.java:165)
    at org.codehaus.mojo.exec.ExecJavaMojo.doMain (ExecJavaMojo.java:385)
    at org.codehaus.mojo.exec.ExecJavaMojo.doExec (ExecJavaMojo.java:374)
    at org.codehaus.mojo.exec.ExecJavaMojo.lambda$execute$0 (ExecJavaMojo.java:296)
    at java.lang.Thread.run (Thread.java:1583)
Caused by: java.lang.ClassNotFoundException: com.oltpbenchmark.benchmarks.tpcc.TPCCBenchmark
    at jdk.internal.loader.BuiltinClassLoader.loadClass (BuiltinClassLoader.java:641)
    at jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass (ClassLoaders.java:188)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:526)
    at java.lang.Class.forName0 (Native Method)
    at java.lang.Class.forName (Class.java:534)
    at java.lang.Class.forName (Class.java:513)
    at org.apache.commons.lang3.ClassUtils.getClass (ClassUtils.java:532)
    at org.apache.commons.lang3.ClassUtils.getClass (ClassUtils.java:514)
    at com.oltpbenchmark.util.ClassUtil.getClass (ClassUtil.java:198)
    at com.oltpbenchmark.util.ClassUtil.getClass (ClassUtil.java:187)
    at com.oltpbenchmark.util.ClassUtil.newInstance (ClassUtil.java:112)
    at com.oltpbenchmark.DBWorkload.main (DBWorkload.java:165)
    at org.codehaus.mojo.exec.ExecJavaMojo.doMain (ExecJavaMojo.java:385)
    at org.codehaus.mojo.exec.ExecJavaMojo.doExec (ExecJavaMojo.java:374)
    at org.codehaus.mojo.exec.ExecJavaMojo.lambda$execute$0 (ExecJavaMojo.java:296)
    at java.lang.Thread.run (Thread.java:1583)
```

The bug was introduced by 611f3d49e8. I believe we should be using `Thread.getCurrentThread().getContextClassLoader()`, not `ClassLoader.getSystemClassLoader()`.