### PR TITLE
Optimize TPCH DDL for faster MySQL loading

### DIFF
--- a/config/mysql/sample_tpch_config.xml
+++ b/config/mysql/sample_tpch_config.xml
@@ -14,10 +14,12 @@
     <!-- Control scale factor to generate different amount of data -->
     <scalefactor>0.1</scalefactor>
 
-    <!-- The post load script is crucial for creating TPCH indices after loading the database. -->
-    <!-- Index creation was removed from the DDL script to speed up the load process. -->
-    <!-- Creating indices post load improves performance by nearly 30%. -->
-    <!-- See src/main/resources/benchmarks/tpch/postload-mysql.sql -->
+    <!--
+        The post load script is crucial for creating TPCH indices after loading the database.
+        Index creation was removed from the DDL script to speed up the load process.
+        Creating indices post load improves performance by nearly 30%.
+        See src/main/resources/benchmarks/tpch/postload-mysql.sql
+    -->
     <afterload>/benchmarks/tpch/postload-mysql.sql</afterload>
 
     <!-- The workload -->

--- a/config/mysql/sample_tpch_config.xml
+++ b/config/mysql/sample_tpch_config.xml
@@ -14,6 +14,12 @@
     <!-- Control scale factor to generate different amount of data -->
     <scalefactor>0.1</scalefactor>
 
+    <!-- The post load script is crucial for creating TPCH indices after loading the database. -->
+    <!-- Index creation was removed from the DDL script to speed up the load process. -->
+    <!-- Creating indices post load improves performance by nearly 30%. -->
+    <!-- See src/main/resources/benchmarks/tpch/postload-mysql.sql -->
+    <afterload>/benchmarks/tpch/postload-mysql.sql</afterload>
+
     <!-- The workload -->
     <terminals>1</terminals>
     <works>

--- a/src/main/resources/benchmarks/tpch/ddl-mysql.sql
+++ b/src/main/resources/benchmarks/tpch/ddl-mysql.sql
@@ -16,7 +16,6 @@ CREATE TABLE region (
     r_comment   varchar(152),
     PRIMARY KEY (r_regionkey)
 );
-CREATE UNIQUE INDEX r_rk ON region (r_regionkey ASC);
 
 CREATE TABLE nation (
     n_nationkey integer  NOT NULL,
@@ -26,8 +25,6 @@ CREATE TABLE nation (
     PRIMARY KEY (n_nationkey),
     FOREIGN KEY (n_regionkey) REFERENCES region (r_regionkey) ON DELETE CASCADE
 );
-CREATE UNIQUE INDEX n_nk ON nation (n_nationkey ASC);
-CREATE INDEX n_rk ON nation (n_regionkey ASC);
 
 CREATE TABLE part (
     p_partkey     integer        NOT NULL,
@@ -41,7 +38,6 @@ CREATE TABLE part (
     p_comment     varchar(23)    NOT NULL,
     PRIMARY KEY (p_partkey)
 );
-CREATE UNIQUE INDEX p_pk ON part (p_partkey ASC);
 
 CREATE TABLE supplier (
     s_suppkey   integer        NOT NULL,
@@ -54,8 +50,6 @@ CREATE TABLE supplier (
     PRIMARY KEY (s_suppkey),
     FOREIGN KEY (s_nationkey) REFERENCES nation (n_nationkey) ON DELETE CASCADE
 );
-CREATE UNIQUE INDEX s_sk ON supplier (s_suppkey ASC);
-CREATE INDEX s_nk ON supplier (s_nationkey ASC);
 
 CREATE TABLE partsupp (
     ps_partkey    integer        NOT NULL,
@@ -67,10 +61,6 @@ CREATE TABLE partsupp (
     FOREIGN KEY (ps_partkey) REFERENCES part (p_partkey) ON DELETE CASCADE,
     FOREIGN KEY (ps_suppkey) REFERENCES supplier (s_suppkey) ON DELETE CASCADE
 );
-CREATE INDEX ps_pk ON partsupp (ps_partkey ASC);
-CREATE INDEX ps_sk ON partsupp (ps_suppkey ASC);
-CREATE UNIQUE INDEX ps_pk_sk ON partsupp (ps_partkey ASC, ps_suppkey ASC);
-CREATE UNIQUE INDEX ps_sk_pk ON partsupp (ps_suppkey ASC, ps_partkey ASC);
 
 CREATE TABLE customer (
     c_custkey    integer        NOT NULL,
@@ -84,8 +74,6 @@ CREATE TABLE customer (
     PRIMARY KEY (c_custkey),
     FOREIGN KEY (c_nationkey) REFERENCES nation (n_nationkey) ON DELETE CASCADE
 );
-CREATE UNIQUE INDEX c_ck ON customer (c_custkey ASC);
-CREATE INDEX c_nk ON customer (c_nationkey ASC);
 
 CREATE TABLE orders (
     o_orderkey      integer        NOT NULL,
@@ -100,9 +88,6 @@ CREATE TABLE orders (
     PRIMARY KEY (o_orderkey),
     FOREIGN KEY (o_custkey) REFERENCES customer (c_custkey) ON DELETE CASCADE
 );
-CREATE UNIQUE INDEX o_ok ON orders (o_orderkey ASC);
-CREATE INDEX o_ck ON orders (o_custkey ASC);
-CREATE INDEX o_od ON orders (o_orderdate ASC);
 
 CREATE TABLE lineitem (
     l_orderkey      integer        NOT NULL,
@@ -125,14 +110,6 @@ CREATE TABLE lineitem (
     FOREIGN KEY (l_orderkey) REFERENCES orders (o_orderkey) ON DELETE CASCADE,
     FOREIGN KEY (l_partkey, l_suppkey) REFERENCES partsupp (ps_partkey, ps_suppkey) ON DELETE CASCADE
 );
-CREATE INDEX l_ok ON lineitem (l_orderkey ASC);
-CREATE INDEX l_pk ON lineitem (l_partkey ASC);
-CREATE INDEX l_sk ON lineitem (l_suppkey ASC);
-CREATE INDEX l_sd ON lineitem (l_shipdate ASC);
-CREATE INDEX l_cd ON lineitem (l_commitdate ASC);
-CREATE INDEX l_rd ON lineitem (l_receiptdate ASC);
-CREATE INDEX l_pk_sk ON lineitem (l_partkey ASC, l_suppkey ASC);
-CREATE INDEX l_sk_pk ON lineitem (l_suppkey ASC, l_partkey ASC);
 
 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;

--- a/src/main/resources/benchmarks/tpch/ddl-mysql.sql
+++ b/src/main/resources/benchmarks/tpch/ddl-mysql.sql
@@ -1,3 +1,13 @@
+/*
+For MySQL, TPCH indices are created post-load. which improves load 
+performance. See src/main/resources/benchmarks/tpch/postload-mysql.sql
+(specified in <afterload> in mysql/sample_tpch_config.xml). When indices
+are created before the load, the insert operations increases overall
+load time by >30%. This happens because every insert needs to update 
+all table indices, which results into additional binlog/redo log updates,
+index seeks, and more data IOPS (if data does not fit in memory).
+*/
+
 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
 

--- a/src/main/resources/benchmarks/tpch/postload-mysql.sql
+++ b/src/main/resources/benchmarks/tpch/postload-mysql.sql
@@ -1,0 +1,24 @@
+
+CREATE UNIQUE INDEX r_rk ON region (r_regionkey ASC);
+CREATE UNIQUE INDEX n_nk ON nation (n_nationkey ASC);
+CREATE INDEX n_rk ON nation (n_regionkey ASC);
+CREATE UNIQUE INDEX p_pk ON part (p_partkey ASC);
+CREATE UNIQUE INDEX s_sk ON supplier (s_suppkey ASC);
+CREATE INDEX s_nk ON supplier (s_nationkey ASC);
+CREATE INDEX ps_pk ON partsupp (ps_partkey ASC);
+CREATE INDEX ps_sk ON partsupp (ps_suppkey ASC);
+CREATE UNIQUE INDEX ps_pk_sk ON partsupp (ps_partkey ASC, ps_suppkey ASC);
+CREATE UNIQUE INDEX ps_sk_pk ON partsupp (ps_suppkey ASC, ps_partkey ASC);
+CREATE UNIQUE INDEX c_ck ON customer (c_custkey ASC);
+CREATE INDEX c_nk ON customer (c_nationkey ASC);
+CREATE UNIQUE INDEX o_ok ON orders (o_orderkey ASC);
+CREATE INDEX o_ck ON orders (o_custkey ASC);
+CREATE INDEX o_od ON orders (o_orderdate ASC);
+CREATE INDEX l_ok ON lineitem (l_orderkey ASC);
+CREATE INDEX l_pk ON lineitem (l_partkey ASC);
+CREATE INDEX l_sk ON lineitem (l_suppkey ASC);
+CREATE INDEX l_sd ON lineitem (l_shipdate ASC);
+CREATE INDEX l_cd ON lineitem (l_commitdate ASC);
+CREATE INDEX l_rd ON lineitem (l_receiptdate ASC);
+CREATE INDEX l_pk_sk ON lineitem (l_partkey ASC, l_suppkey ASC);
+CREATE INDEX l_sk_pk ON lineitem (l_suppkey ASC, l_partkey ASC);

--- a/src/main/resources/benchmarks/tpch/postload-mysql.sql
+++ b/src/main/resources/benchmarks/tpch/postload-mysql.sql
@@ -1,4 +1,9 @@
-
+/*
+This script runs after TPCH table creation and data loading.
+It improves overall load performance by approximately 30%.
+This script is referenced by the <afterLoad> parameter in
+mysql/sample_tpch_config.xml.
+*/
 CREATE UNIQUE INDEX r_rk ON region (r_regionkey ASC);
 CREATE UNIQUE INDEX n_nk ON nation (n_nationkey ASC);
 CREATE INDEX n_rk ON nation (n_regionkey ASC);


### PR DESCRIPTION
This pull request includes changes to improve the performance of loading the TPCH database on a MySQL instance by deferring index creation to a post-load script. The most important changes include adding a new post-load script reference and removing index creation statements from the DDL script.

Performance improvements:

* [`config/mysql/sample_tpch_config.xml`](diffhunk://#diff-a48fec690069601e7837968f1848c04583a74352c5d98597f05e55794fd7cb00R17-R22): Added a reference to the new post-load script `postload-mysql.sql` to create indices after loading the database, which improves performance by nearly 30%.

Codebase simplification:

* [`src/main/resources/benchmarks/tpch/ddl-mysql.sql`](diffhunk://#diff-d0e0637fb2f0a9ee276e7046d3e142c830e9a652deb6a15afb2a1733e15d3caeL19): Removed all index creation statements from the DDL script to speed up the initial load process. [[1]](diffhunk://#diff-d0e0637fb2f0a9ee276e7046d3e142c830e9a652deb6a15afb2a1733e15d3caeL19) [[2]](diffhunk://#diff-d0e0637fb2f0a9ee276e7046d3e142c830e9a652deb6a15afb2a1733e15d3caeL29-L30) [[3]](diffhunk://#diff-d0e0637fb2f0a9ee276e7046d3e142c830e9a652deb6a15afb2a1733e15d3caeL44) [[4]](diffhunk://#diff-d0e0637fb2f0a9ee276e7046d3e142c830e9a652deb6a15afb2a1733e15d3caeL57-L58) [[5]](diffhunk://#diff-d0e0637fb2f0a9ee276e7046d3e142c830e9a652deb6a15afb2a1733e15d3caeL70-L73) [[6]](diffhunk://#diff-d0e0637fb2f0a9ee276e7046d3e142c830e9a652deb6a15afb2a1733e15d3caeL87-L88) [[7]](diffhunk://#diff-d0e0637fb2f0a9ee276e7046d3e142c830e9a652deb6a15afb2a1733e15d3caeL103-L105) [[8]](diffhunk://#diff-d0e0637fb2f0a9ee276e7046d3e142c830e9a652deb6a15afb2a1733e15d3caeL128-L135)
* [`src/main/resources/benchmarks/tpch/postload-mysql.sql`](diffhunk://#diff-b8a6513014cff301d33e49c05085cbc3c32a97d5b1696d14739b0da57ed9f154R1-R24): Added the removed index creation statements to this new post-load script to be executed after the data load is complete.