### PR TITLE
Fixups advanced monitor CI pipeline checks

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -538,7 +538,7 @@ jobs:
           ./scripts/check_histogram_results.sh results/histograms.json $ERRORS_THRESHOLD
 
           # Running the monitor should create at least three files in the 'monitor' directory.
-          if ![ $(find "./results/monitor" -maxdepth 1 -mindepth 1 | wc -l) -gt 2]; then
+          if ! [ $(find "./results/monitor" -maxdepth 1 -mindepth 1 | wc -l) -gt 2 ]; then
             echo "ERROR: Advanced monitoring unsuccessful, file directory and/or appropriate files not created." >&2
             exit 1
           fi
@@ -721,7 +721,7 @@ jobs:
           ./scripts/check_histogram_results.sh results/histograms.json $ERRORS_THRESHOLD
 
           # Running the monitor should create at least three files in the 'monitor' directory.
-          if ![ $(find "./results/monitor" -maxdepth 1 -mindepth 1 | wc -l) -gt 2]; then
+          if ! [ $(find "./results/monitor" -maxdepth 1 -mindepth 1 | wc -l) -gt 2 ]; then
             echo "ERROR: Advanced monitoring unsuccessful, file directory and/or appropriate files not created." >&2
             exit 1
           fi


### PR DESCRIPTION
There's an error in the shell script for the CI pipeline checks.

However, fixing it also causes the checks to fail.  Should investigate this.

#300 